### PR TITLE
[Fix] post-details CTA 버튼 동작 수정

### DIFF
--- a/src/pages/post-details/post-details.tsx
+++ b/src/pages/post-details/post-details.tsx
@@ -43,6 +43,12 @@ const PostDetailPage = () => {
     if (pendingRef.current) return;
 
     const numericPostId = Number(postId);
+
+    if (!Number.isInteger(numericPostId) || numericPostId <= 0) {
+      toast.error('유효하지 않은 공고입니다.');
+      return;
+    }
+
     const wasApplied = isApplied;
     const nextApplied = !wasApplied;
 

--- a/src/pages/post-details/post-details.tsx
+++ b/src/pages/post-details/post-details.tsx
@@ -1,6 +1,7 @@
 import { ROUTE_BUILDER } from '@shared/constants/path';
 import CtaButton from '@shared/ui/components/cta-button/cta-button';
 import { useToast } from '@shared/ui/components/toast/toast-context';
+import { useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 
 import { MOCK_POST_DETAIL } from './mock/mock-post-detail';
@@ -11,6 +12,13 @@ import { toRecruitDetailTextProps } from './widgets/recruit-detail-text/adapter'
 import RecruitDetailText from './widgets/recruit-detail-text/recruit-detail-text';
 import { toRecruitInfoProps } from './widgets/recruit-info/adapter';
 import RecruitInfo from './widgets/recruit-info/recruit-info';
+
+const requestToggleApply = async (postId: number, nextApplied: boolean) => {
+  // TODO: API 연결
+  await new Promise((resolve) => setTimeout(resolve, 300));
+
+  return { postId, applied: nextApplied };
+};
 
 const PostDetailPage = () => {
   const navigate = useNavigate();
@@ -26,9 +34,33 @@ const PostDetailPage = () => {
   // TODO: API 연결 후 유저 권한/지원 여부 기반으로 분기
   const isAuthor = false;
 
-  const handleApply = () => {
+  const [isApplied, setIsApplied] = useState(false);
+  const pendingRef = useRef(false);
+
+  const handleToggleApply = async () => {
     // TODO: 지원하기 API 연결
-    toast.success('지원이 완료되었어요.');
+    if (!postId) return;
+    if (pendingRef.current) return;
+
+    const numericPostId = Number(postId);
+    const wasApplied = isApplied;
+    const nextApplied = !wasApplied;
+
+    setIsApplied(nextApplied);
+    pendingRef.current = true;
+
+    try {
+      await requestToggleApply(numericPostId, nextApplied);
+
+      toast.success(
+        nextApplied ? '지원이 완료되었어요.' : '지원이 취소되었어요.',
+      );
+    } catch {
+      setIsApplied(wasApplied);
+      toast.error('서버 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
+    } finally {
+      pendingRef.current = false;
+    }
   };
 
   const handleDelete = () => {
@@ -65,8 +97,12 @@ const PostDetailPage = () => {
                   수정하기
                 </CtaButton>
               </>
+            ) : isApplied ? (
+              <CtaButton color='gray' onClick={handleToggleApply}>
+                지원 취소
+              </CtaButton>
             ) : (
-              <CtaButton color='primary' onClick={handleApply}>
+              <CtaButton color='primary' onClick={handleToggleApply}>
                 지원하기
               </CtaButton>
             )}


### PR DESCRIPTION
## 📌 Summary

> #72
post-details CTA 버튼 동작 수정

## 📚 Tasks

- [X] post-details CTA 버튼 동작 수정
- [X] 성공, 실패 토스트 추가

## 🔍 Describe

공고 상세페이지에서 지원하기 버튼을 누르면 버튼 내 문구가 '지원 취소'로 바뀌고, 색상도 gray로 바뀌도록 수정했어요. 추가로, 지원 요청 성공/실패 여부에 따라 토스트 메시지를 띄우도록 틀을 잡았습니다. 추후 API 연결 작업에서 정리가 들어가야 하는 부분들은 TODO 주석을 남겨 두었어요.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 지원 신청/취소 동작이 중복 제출을 방지하고 진행 상태를 반영하도록 개선
  * UI를 즉시 반영(낙관적 업데이트)하고 실패 시 자동으로 되돌림
  * 지원 완료/취소 시 각각 다른 성공 메시지 표시 및 실패 시 오류 안내 표기
  * 버튼 레이블을 상황에 따라 "지원하기" 또는 회색 "지원 취소"로 명확화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->