### PR TITLE
[Feat] 추천받기 페이지에 탭 컴포넌트 추가

### DIFF
--- a/src/pages/recommend/recommend.css.ts
+++ b/src/pages/recommend/recommend.css.ts
@@ -33,3 +33,7 @@ export const sectionContainer = style({
   flexDirection: 'column',
   gap: '1rem',
 });
+
+export const tabBarContainer = style({
+  marginTop: '3rem',
+});

--- a/src/pages/recommend/recommend.tsx
+++ b/src/pages/recommend/recommend.tsx
@@ -1,8 +1,11 @@
 import Banner from '@shared/ui/components/banner/banner';
+import { useState } from 'react';
 
 import * as styles from './recommend.css';
 import ApplicantSection from './widgets/applicant-section/applicant-section';
 import RecommendSection from './widgets/recommend-section/recommend-section';
+import type { TabLabelTypes } from './widgets/tab-bar/tab-bar';
+import TabBar from './widgets/tab-bar/tab-bar';
 
 interface RecommendPost {
   postId: number;
@@ -15,6 +18,8 @@ const MOCK_RECOMMEND_POSTS: RecommendPost[] = [
 ];
 
 const RecommendPage = () => {
+  const [activeTab, setActiveTab] = useState<TabLabelTypes>('recommend');
+
   return (
     <>
       <section className={styles.bannerContainer}>
@@ -22,15 +27,20 @@ const RecommendPage = () => {
       </section>
 
       <main className={styles.pageContainer}>
+        <section className={styles.tabBarContainer}>
+          <TabBar activeTab={activeTab} onChangeTab={setActiveTab} />
+        </section>
         <section className={styles.sectionContainer}>
           {MOCK_RECOMMEND_POSTS.map((post) => (
             <div key={post.postId}>
-              <RecommendSection postId={post.postId} />
-
-              <ApplicantSection
-                postId={post.postId}
-                postTitle={post.postTitle}
-              />
+              {activeTab === 'recommend' ? (
+                <RecommendSection postId={post.postId} />
+              ) : (
+                <ApplicantSection
+                  postId={post.postId}
+                  postTitle={post.postTitle}
+                />
+              )}
             </div>
           ))}
         </section>

--- a/src/pages/recommend/widgets/tab-bar/tab-bar.css.ts
+++ b/src/pages/recommend/widgets/tab-bar/tab-bar.css.ts
@@ -1,0 +1,33 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+export const tabContainer = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: '1.6rem',
+});
+
+export const tabButton = recipe({
+  base: {
+    display: 'flex',
+    ...themeVars.font.body_20sb,
+  },
+
+  variants: {
+    isActive: {
+      true: {
+        color: themeVars.color.gray_900,
+      },
+      false: {
+        color: themeVars.color.gray_400,
+      },
+    },
+  },
+});
+
+export const divider = style({
+  width: '0.2rem',
+  height: '1.8rem',
+  backgroundColor: themeVars.color.gray_400,
+});

--- a/src/pages/recommend/widgets/tab-bar/tab-bar.tsx
+++ b/src/pages/recommend/widgets/tab-bar/tab-bar.tsx
@@ -1,0 +1,32 @@
+import * as styles from './tab-bar.css';
+
+export type TabLabelTypes = 'recommend' | 'applicant';
+
+interface TabBarProps {
+  activeTab: TabLabelTypes;
+  onChangeTab: (tab: TabLabelTypes) => void;
+}
+
+const TabBar = ({ activeTab, onChangeTab }: TabBarProps) => {
+  return (
+    <div className={styles.tabContainer}>
+      <button
+        type='button'
+        className={styles.tabButton({ isActive: activeTab === 'recommend' })}
+        onClick={() => onChangeTab('recommend')}
+      >
+        팀원 추천받기
+      </button>
+      <div className={styles.divider} />
+      <button
+        type='button'
+        className={styles.tabButton({ isActive: activeTab === 'applicant' })}
+        onClick={() => onChangeTab('applicant')}
+      >
+        지원한 팀원 보기
+      </button>
+    </div>
+  );
+};
+
+export default TabBar;

--- a/src/pages/recommend/widgets/tab-bar/tab-bar.tsx
+++ b/src/pages/recommend/widgets/tab-bar/tab-bar.tsx
@@ -13,6 +13,7 @@ const TabBar = ({ activeTab, onChangeTab }: TabBarProps) => {
       <button
         type='button'
         className={styles.tabButton({ isActive: activeTab === 'recommend' })}
+        aria-pressed={activeTab === 'recommend'}
         onClick={() => onChangeTab('recommend')}
       >
         팀원 추천받기
@@ -21,6 +22,7 @@ const TabBar = ({ activeTab, onChangeTab }: TabBarProps) => {
       <button
         type='button'
         className={styles.tabButton({ isActive: activeTab === 'applicant' })}
+        aria-pressed={activeTab === 'applicant'}
         onClick={() => onChangeTab('applicant')}
       >
         지원한 팀원 보기


### PR DESCRIPTION
## 📌 Summary

> #74 
추천받기 페이지에 탭 컴포넌트 추가

## 📚 Tasks

- [X] 탭 컴포넌트 구현

## 🔍 Describe

기존에는 한 페이지 안에서 모든 공고의 지원자 / 추천자 리스트를 보여주고 있어서 스크롤이 길어지고, 사용성을 해치고 있었어요. 이를 방지하기 위해 '팀원 추천받기', '지원한 팀원 보기' 메뉴 선택에 따라 RecommendSection 또는 ApplicantSection을 렌더링하는 탭 바 컴포넌트를 구현했습니다. 이 페이지에서만 사용될 예정이라 컴파운드 패턴은 과한 것 같아 고려하지 않았어요.

## 👀 To Reviewer
개선안 있는지 확인부탁드립니당


## 📸 Screenshot
<img width="285" height="71" alt="image" src="https://github.com/user-attachments/assets/1d7edf5b-7712-480a-be3a-e1b2715ca203" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 추천 페이지에 탭 기반 네비게이션 추가: "팀원 추천받기"와 "지원한 팀원 보기"를 전환해 각 섹션을 개별적으로 확인할 수 있습니다.
  * 탭 선택에 따라 게시물 목록의 표시 내용이 동적으로 변경됩니다.

* **Style**
  * 탭 레이아웃과 상단 여백 조정 등 UI 스타일이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->