### PR TITLE
[Feat] 페이지 전체 필터 검색 영역에 초기화 버튼 추가

### DIFF
--- a/src/pages/members/members.css.ts
+++ b/src/pages/members/members.css.ts
@@ -43,3 +43,15 @@ export const dropdownContainer = style({
   justifyContent: 'space-between',
   marginBottom: '2rem',
 });
+
+export const refreshButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  color: themeVars.color.gray_400,
+  ...themeVars.font.body_18r,
+});
+
+export const icon = style({
+  width: '2.4rem',
+  height: '2.4rem',
+});

--- a/src/pages/members/members.css.ts
+++ b/src/pages/members/members.css.ts
@@ -33,12 +33,13 @@ export const sectionHeader = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
+  minHeight: '4.1rem',
   margin: '2rem 0',
   color: themeVars.color.gray_800,
   ...themeVars.font.body_20sb,
 });
 
-export const dropdownContainer = style({
+export const filterContainer = style({
   display: 'flex',
   justifyContent: 'space-between',
   marginBottom: '2rem',

--- a/src/pages/members/members.tsx
+++ b/src/pages/members/members.tsx
@@ -15,6 +15,7 @@ import { MOCK_MEMBERS_RESPONSE } from './mocks/mock-members';
 import { MOCK_PERSONALITY_FILTER_RESPONSE } from './mocks/mock-personality-filter-response';
 import { MOCK_FIELD_SKILL_RESPONSE } from './mocks/mock-skill-options';
 import MemberCardGroup from './widgets/member-card-group/member-card-group';
+import { ResetIcon } from '@shared/assets/icons';
 
 const MembersPage = () => {
   const [filters, setFilters] =
@@ -43,6 +44,10 @@ const MembersPage = () => {
     return toMemberCardModels(filteredMembers);
   }, [filteredMembers]);
 
+  const handleRefresh = () => {
+    setFilters(EMPTY_MEMBER_FILTERS);
+  };
+
   return (
     <>
       <section className={styles.bannerContainer}>
@@ -64,6 +69,15 @@ const MembersPage = () => {
             value={filters}
             onChange={setFilters}
           />
+
+          <button
+            type='button'
+            className={styles.refreshButton}
+            onClick={handleRefresh}
+          >
+            <span>새로고침</span>
+            <ResetIcon className={styles.icon} />
+          </button>
         </section>
 
         <MemberCardGroup members={memberCardModels} />

--- a/src/pages/members/members.tsx
+++ b/src/pages/members/members.tsx
@@ -3,6 +3,7 @@ import { filterMembers } from '@features/members/model/filter-members';
 import type { MemberFiltersState } from '@features/members/model/filter-state';
 import { EMPTY_MEMBER_FILTERS } from '@features/members/model/filter-state';
 import type { PersonalityFilterItem } from '@features/members/types/member-filter-meta-response';
+import { ResetIcon } from '@shared/assets/icons';
 import { parseFieldRoleResponse } from '@shared/lib/filter/parse-field-role-response';
 import { parseFieldSkillResponse } from '@shared/lib/filter/parse-field-skill-response';
 import Banner from '@shared/ui/components/banner/banner';
@@ -15,7 +16,6 @@ import { MOCK_MEMBERS_RESPONSE } from './mocks/mock-members';
 import { MOCK_PERSONALITY_FILTER_RESPONSE } from './mocks/mock-personality-filter-response';
 import { MOCK_FIELD_SKILL_RESPONSE } from './mocks/mock-skill-options';
 import MemberCardGroup from './widgets/member-card-group/member-card-group';
-import { ResetIcon } from '@shared/assets/icons';
 
 const MembersPage = () => {
   const [filters, setFilters] =

--- a/src/pages/members/members.tsx
+++ b/src/pages/members/members.tsx
@@ -59,7 +59,7 @@ const MembersPage = () => {
           <p>전체 팀원 모아보기</p>
         </section>
 
-        <section className={styles.dropdownContainer}>
+        <section className={styles.filterContainer}>
           <MemberDropdownGroup
             roleFields={roleFields}
             rolesByFieldOptions={rolesByFieldOptions}

--- a/src/pages/posts/post.css.ts
+++ b/src/pages/posts/post.css.ts
@@ -42,7 +42,7 @@ export const writeButtonContainer = style({
   width: '15.2rem',
 });
 
-export const dropdownContainer = style({
+export const filterContainer = style({
   display: 'flex',
   justifyContent: 'space-between',
   marginBottom: '2rem',
@@ -69,4 +69,16 @@ export const emptyContainer = style({
 export const emptyText = style({
   color: themeVars.color.gray_500,
   ...themeVars.font.body_18r,
+});
+
+export const refreshButton = style({
+  display: 'flex',
+  alignItems: 'center',
+  color: themeVars.color.gray_400,
+  ...themeVars.font.body_18r,
+});
+
+export const icon = style({
+  width: '2.4rem',
+  height: '2.4rem',
 });

--- a/src/pages/posts/posts.tsx
+++ b/src/pages/posts/posts.tsx
@@ -1,5 +1,6 @@
 import { filterPosts } from '@features/posts/model/filter-posts';
 import { EMPTY_FILTERS } from '@features/posts/model/filters-state';
+import { ResetIcon } from '@shared/assets/icons';
 import { parseFieldRoleResponse } from '@shared/lib/filter/parse-field-role-response';
 import Banner from '@shared/ui/components/banner/banner';
 import Button from '@shared/ui/components/button/button';
@@ -88,6 +89,11 @@ const PostsPage = () => {
     }
   };
 
+  const handleRefresh = () => {
+    setFilters(EMPTY_FILTERS);
+    // TODO: API 연결 이후에는 필터 초기화와 함께 추천 팀원 목록 재조회도 함께 수행한다.
+  };
+
   return (
     <>
       <section className={styles.bannerContainer}>
@@ -104,7 +110,7 @@ const PostsPage = () => {
           </div>
         </section>
 
-        <section className={styles.dropdownContainer}>
+        <section className={styles.filterContainer}>
           <PostDropdownGroup
             domains={MOCK_DOMAIN_OPTIONS}
             fields={fields}
@@ -112,6 +118,15 @@ const PostsPage = () => {
             value={filters}
             onChange={setFilters}
           />
+
+          <button
+            type='button'
+            className={styles.refreshButton}
+            onClick={handleRefresh}
+          >
+            <span>새로고침</span>
+            <ResetIcon className={styles.icon} />
+          </button>
         </section>
 
         {filteredPosts.length === 0 ? (

--- a/src/pages/posts/posts.tsx
+++ b/src/pages/posts/posts.tsx
@@ -91,7 +91,6 @@ const PostsPage = () => {
 
   const handleRefresh = () => {
     setFilters(EMPTY_FILTERS);
-    // TODO: API 연결 이후에는 필터 초기화와 함께 추천 팀원 목록 재조회도 함께 수행한다.
   };
 
   return (

--- a/src/pages/recommend/widgets/applicant-section/applicant-section.css.ts
+++ b/src/pages/recommend/widgets/applicant-section/applicant-section.css.ts
@@ -13,7 +13,7 @@ export const sectionTitle = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginTop: '1rem',
+  margin: '1rem 0',
   color: themeVars.color.gray_800,
   ...themeVars.font.body_20sb,
 });

--- a/src/pages/recommend/widgets/applicant-section/applicant-section.css.ts
+++ b/src/pages/recommend/widgets/applicant-section/applicant-section.css.ts
@@ -30,7 +30,7 @@ export const icon = style({
   height: '2.4rem',
 });
 
-export const dropdownContainer = style({
+export const filterContainer = style({
   display: 'flex',
   justifyContent: 'space-between',
   marginBottom: '1rem',

--- a/src/pages/recommend/widgets/applicant-section/applicant-section.tsx
+++ b/src/pages/recommend/widgets/applicant-section/applicant-section.tsx
@@ -56,17 +56,9 @@ const ApplicantSection = ({ postId, postTitle }: ApplicantSectionProps) => {
     <>
       <section className={styles.sectionTitleContainer}>
         <p className={styles.sectionTitle}>'{postTitle}'에 지원한 팀원 보기</p>
-        <button
-          type='button'
-          className={styles.refreshButton}
-          onClick={handleRefresh}
-        >
-          <span>새로고침</span>
-          <ResetIcon className={styles.icon} />
-        </button>
       </section>
 
-      <section className={styles.dropdownContainer}>
+      <section className={styles.filterContainer}>
         <MemberDropdownGroup
           roleFields={roleFields}
           rolesByFieldOptions={rolesByFieldOptions}
@@ -76,6 +68,15 @@ const ApplicantSection = ({ postId, postTitle }: ApplicantSectionProps) => {
           value={filters}
           onChange={setFilters}
         />
+
+        <button
+          type='button'
+          className={styles.refreshButton}
+          onClick={handleRefresh}
+        >
+          <span>새로고침</span>
+          <ResetIcon className={styles.icon} />
+        </button>
       </section>
 
       <ApplicantMemberGroup members={cardMembers} />

--- a/src/pages/recommend/widgets/recommend-section/recommend-section.css.ts
+++ b/src/pages/recommend/widgets/recommend-section/recommend-section.css.ts
@@ -13,7 +13,7 @@ export const sectionTitle = style({
   display: 'flex',
   justifyContent: 'space-between',
   alignItems: 'center',
-  marginTop: '1rem',
+  margin: '1rem 0',
   color: themeVars.color.gray_800,
   ...themeVars.font.body_20sb,
 });

--- a/src/pages/recommend/widgets/recommend-section/recommend-section.css.ts
+++ b/src/pages/recommend/widgets/recommend-section/recommend-section.css.ts
@@ -30,7 +30,7 @@ export const icon = style({
   height: '2.4rem',
 });
 
-export const dropdownContainer = style({
+export const filterContainer = style({
   display: 'flex',
   justifyContent: 'space-between',
   marginBottom: '1rem',

--- a/src/pages/recommend/widgets/recommend-section/recommend-section.tsx
+++ b/src/pages/recommend/widgets/recommend-section/recommend-section.tsx
@@ -307,15 +307,6 @@ const RecommendSection = ({ postId }: RecommendSectionProps) => {
         <p className={styles.sectionTitle}>
           '{MOCK_RECOMMEND_RESPONSE.data.title}'에 핏한 팀원 보기
         </p>
-
-        {/* <button
-          type='button'
-          className={styles.refreshButton}
-          onClick={handleRefresh}
-        >
-          <span>새로고침</span>
-          <ResetIcon className={styles.icon} />
-        </button> */}
       </section>
 
       <section className={styles.filterContainer}>

--- a/src/pages/recommend/widgets/recommend-section/recommend-section.tsx
+++ b/src/pages/recommend/widgets/recommend-section/recommend-section.tsx
@@ -308,17 +308,17 @@ const RecommendSection = ({ postId }: RecommendSectionProps) => {
           '{MOCK_RECOMMEND_RESPONSE.data.title}'에 핏한 팀원 보기
         </p>
 
-        <button
+        {/* <button
           type='button'
           className={styles.refreshButton}
           onClick={handleRefresh}
         >
           <span>새로고침</span>
           <ResetIcon className={styles.icon} />
-        </button>
+        </button> */}
       </section>
 
-      <section className={styles.dropdownContainer}>
+      <section className={styles.filterContainer}>
         <MemberDropdownGroup
           roleFields={roleFields}
           rolesByFieldOptions={rolesByFieldOptions}
@@ -328,6 +328,15 @@ const RecommendSection = ({ postId }: RecommendSectionProps) => {
           value={filters}
           onChange={setFilters}
         />
+
+        <button
+          type='button'
+          className={styles.refreshButton}
+          onClick={handleRefresh}
+        >
+          <span>새로고침</span>
+          <ResetIcon className={styles.icon} />
+        </button>
       </section>
 
       <RecommendMemberGroup members={cardMembers} />


### PR DESCRIPTION
## 📌 Summary

> #76 
페이지 전체 필터 검색 영역에 초기화 버튼 추가

## 📚 Tasks

- [X] 초기화 버튼의 위치를 filterContainer 내부로 이동
- [X] 스타일 일관성 개선
- [X] 페이지 전체 필터 검색 영역에 초기화 버튼 추가

## 🔍 Describe

드롭다운 검색 영역에 검색 옵션을 초기화하는 새로고침 버튼을 추가했어요.
추후 API 연결 작업을 진행하며 함수 부분을 추가로 수정할 예정이에요.

또한 공고 페이지와 팀원 모아보기 페이지에서 간격이 조금씩 다른 부분도 있어 스타일이 일관되도록 CSS를 소폭 수정했습니다.


## 👀 To Reviewer
CSS 잘 통일되어 있는지... 수정사항 없는지 확인해주세요~

## 📸 Screenshot
<img width="1558" height="127" alt="image" src="https://github.com/user-attachments/assets/2b3f0e46-880d-4a05-bd77-6379b8a35873" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 멤버·게시글·추천 페이지에 ‘새로고침’ 필터 초기화 버튼과 아이콘을 추가했습니다.

* **스타일**
  * 필터 컨테이너 명칭 및 레이아웃을 통일하고 여백을 조정해 UI 일관성을 개선했습니다.
  * 섹션 제목 및 헤더 높이와 관련된 여백/최소 높이 조정과, 버튼·아이콘 스타일(크기·정렬·글꼴·색상)을 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->