### PR TITLE
[Refactor] FSD 원칙 준수를 위한 filter.ts 책임 분리

### DIFF
--- a/src/entities/domain/types.ts
+++ b/src/entities/domain/types.ts
@@ -1,0 +1,3 @@
+import type { Option } from '@shared/types/common';
+
+export type DomainResponse = Option;

--- a/src/entities/field-role/types.ts
+++ b/src/entities/field-role/types.ts
@@ -1,10 +1,3 @@
-export interface Option {
-  id: number;
-  name: string;
-}
-
-export type DomainResponse = Option;
-
 export interface FieldRoleItemResponse {
   roleId: number;
   roleName: string;

--- a/src/features/members/types/member-filter-meta-response.ts
+++ b/src/features/members/types/member-filter-meta-response.ts
@@ -1,5 +1,5 @@
 import type { SuccessResponse } from '@shared/api/types';
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 import type {
   PersonalityKey,
   PersonalityValue,

--- a/src/pages/members/mocks/mock-skill-options.ts
+++ b/src/pages/members/mocks/mock-skill-options.ts
@@ -1,5 +1,5 @@
 import type { SuccessResponse } from '@shared/api/types';
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 export interface FieldSkillItemResponse {
   field: Option;

--- a/src/pages/post-create/mocks/mock-post-create-options.ts
+++ b/src/pages/post-create/mocks/mock-post-create-options.ts
@@ -1,9 +1,6 @@
-export interface PostFormOption {
-  id: number;
-  name: string;
-}
+import type { Option } from '@shared/types/common';
 
-export const MOCK_DOMAIN_OPTIONS: PostFormOption[] = [
+export const MOCK_DOMAIN_OPTIONS: Option[] = [
   { id: 1, name: 'IT/개발' },
   { id: 2, name: '디자인' },
   { id: 3, name: '기획' },

--- a/src/pages/post-create/mocks/mock-post-role-options.ts
+++ b/src/pages/post-create/mocks/mock-post-role-options.ts
@@ -1,8 +1,8 @@
-import type { PostFormOption } from './mock-post-create-options';
+import type { Option } from '@shared/types/common';
 
 interface FieldRoleOptionGroup {
-  field: PostFormOption;
-  roles: PostFormOption[];
+  field: Option;
+  roles: Option[];
 }
 
 const MOCK_FIELD_ROLE_OPTION_GROUPS: FieldRoleOptionGroup[] = [
@@ -41,11 +41,12 @@ const MOCK_FIELD_ROLE_OPTION_GROUPS: FieldRoleOptionGroup[] = [
   },
 ];
 
-export const MOCK_ROLE_FIELDS: PostFormOption[] =
-  MOCK_FIELD_ROLE_OPTION_GROUPS.map(({ field }) => field);
+export const MOCK_ROLE_FIELDS: Option[] = MOCK_FIELD_ROLE_OPTION_GROUPS.map(
+  ({ field }) => field,
+);
 
-export const MOCK_ROLES_BY_FIELD_OPTIONS: Record<number, PostFormOption[]> =
-  MOCK_FIELD_ROLE_OPTION_GROUPS.reduce<Record<number, PostFormOption[]>>(
+export const MOCK_ROLES_BY_FIELD_OPTIONS: Record<number, Option[]> =
+  MOCK_FIELD_ROLE_OPTION_GROUPS.reduce<Record<number, Option[]>>(
     (acc, { field, roles }) => {
       acc[field.id] = roles;
       return acc;
@@ -53,5 +54,5 @@ export const MOCK_ROLES_BY_FIELD_OPTIONS: Record<number, PostFormOption[]> =
     {},
   );
 
-export const MOCK_ALL_ROLE_OPTIONS: PostFormOption[] =
+export const MOCK_ALL_ROLE_OPTIONS: Option[] =
   MOCK_FIELD_ROLE_OPTION_GROUPS.flatMap(({ roles }) => roles);

--- a/src/pages/posts/mock/mock-domain-options.ts
+++ b/src/pages/posts/mock/mock-domain-options.ts
@@ -1,4 +1,4 @@
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 export const MOCK_DOMAIN_OPTIONS: Option[] = [
   { id: 1, name: 'IT' },

--- a/src/pages/posts/mock/mock-field-role-response.ts
+++ b/src/pages/posts/mock/mock-field-role-response.ts
@@ -1,5 +1,5 @@
+import type { GetFieldRoleResponse } from '@entities/field-role/types';
 import type { SuccessResponse } from '@shared/api/types';
-import type { GetFieldRoleResponse } from '@shared/types/filter/filter';
 
 export type FieldRoleResponse = SuccessResponse<GetFieldRoleResponse>;
 

--- a/src/shared/lib/filter/parse-field-role-response.ts
+++ b/src/shared/lib/filter/parse-field-role-response.ts
@@ -1,7 +1,5 @@
-import type {
-  FieldRoleItemResponse,
-  Option,
-} from '@shared/types/filter/filter';
+import type { FieldRoleItemResponse } from '@entities/field-role/types';
+import type { Option } from '@shared/types/common';
 
 interface ParsedFieldRoleResponse {
   fields: Option[];

--- a/src/shared/lib/filter/parse-field-skill-response.ts
+++ b/src/shared/lib/filter/parse-field-skill-response.ts
@@ -1,4 +1,4 @@
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 interface FieldSkillFilterItem {
   field: Option;

--- a/src/shared/types/common.ts
+++ b/src/shared/types/common.ts
@@ -1,0 +1,4 @@
+export interface Option {
+  id: number;
+  name: string;
+}

--- a/src/shared/ui/components/dropdown/dropdown-content/domain-content.tsx
+++ b/src/shared/ui/components/dropdown/dropdown-content/domain-content.tsx
@@ -1,4 +1,4 @@
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 import * as styles from './dropdown-content.css';
 

--- a/src/shared/ui/components/dropdown/dropdown-content/field-role-content.tsx
+++ b/src/shared/ui/components/dropdown/dropdown-content/field-role-content.tsx
@@ -1,4 +1,4 @@
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 import * as styles from './dropdown-content.css';
 

--- a/src/shared/ui/components/dropdown/dropdown-content/field-skill-content.tsx
+++ b/src/shared/ui/components/dropdown/dropdown-content/field-skill-content.tsx
@@ -1,4 +1,4 @@
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 
 import * as styles from './dropdown-content.css';
 

--- a/src/widgets/member-dropdown-group/member-dropdown-group.tsx
+++ b/src/widgets/member-dropdown-group/member-dropdown-group.tsx
@@ -1,6 +1,6 @@
 import type { MemberFiltersState } from '@features/members/model/filter-state';
 import type { PersonalityFilterItem } from '@features/members/types/member-filter-meta-response';
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 import {
   Dropdown,
   DropdownPanel,

--- a/src/widgets/post-dropdown-group/post-dropdown-group.tsx
+++ b/src/widgets/post-dropdown-group/post-dropdown-group.tsx
@@ -1,5 +1,5 @@
 import type { FiltersState } from '@features/posts/model/filters-state';
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 import {
   DomainContent,
   Dropdown,

--- a/src/widgets/post-form/post-form-content.tsx
+++ b/src/widgets/post-form/post-form-content.tsx
@@ -2,7 +2,7 @@ import type {
   PostFormValues,
   RoleCountValue,
 } from '@entities/posts/model/post-form/post-form';
-import type { PostFormOption } from '@pages/post-create/mocks/mock-post-create-options';
+import type { Option } from '@shared/types/common';
 import CtaButton from '@shared/ui/components/cta-button/cta-button';
 import { type Dispatch, type SetStateAction, useState } from 'react';
 
@@ -28,10 +28,10 @@ const createEmptyPendingRoleInput = (): PendingRoleInput => ({
 interface PostFormContentProps {
   values: PostFormValues;
   onChange: (next: PostFormValues) => void;
-  domainOptions: PostFormOption[];
-  roleFields: PostFormOption[];
-  rolesByFieldOptions: Record<number, PostFormOption[]>;
-  allRoleOptions: PostFormOption[];
+  domainOptions: Option[];
+  roleFields: Option[];
+  rolesByFieldOptions: Record<number, Option[]>;
+  allRoleOptions: Option[];
   onSubmit: () => void;
 }
 

--- a/src/widgets/post-form/ui/post-basic-info-section/post-basic-info-section.tsx
+++ b/src/widgets/post-form/ui/post-basic-info-section/post-basic-info-section.tsx
@@ -1,4 +1,4 @@
-import type { PostFormOption } from '@pages/post-create/mocks/mock-post-create-options';
+import type { Option } from '@shared/types/common';
 import {
   DomainContent,
   Dropdown,
@@ -21,7 +21,7 @@ interface PostBasicInfoSectionProps {
   };
   homepageUrl: string;
   contact: string;
-  domainOptions: PostFormOption[];
+  domainOptions: Option[];
   onChangeTitle: (value: string) => void;
   onChangeDomains: (value: number[]) => void;
   onChangeRecruitPeriod: (next: { startDate: string; endDate: string }) => void;

--- a/src/widgets/post-form/ui/post-role-section/post-role-section.tsx
+++ b/src/widgets/post-form/ui/post-role-section/post-role-section.tsx
@@ -1,6 +1,6 @@
 import type { RoleCountValue } from '@entities/posts/model/post-form/post-form';
 import { ProfileIcon, XIcon } from '@shared/assets/icons';
-import type { Option } from '@shared/types/filter/filter';
+import type { Option } from '@shared/types/common';
 import Button from '@shared/ui/components/button/button';
 import {
   Dropdown,


### PR DESCRIPTION
## 📌 Summary

> #83 
FSD 원칙 준수를 위한 filter.ts 책임 분리

## 📚 Tasks
- Option → @shared/types/common.ts 로 이동
- DomainResponse → @entities/domain/types.ts 로 이동
- FieldRoleItemResponse, GetFieldRoleResponse → @entities/field-role/types.ts 로 이동
- PostFormOption 제거 후 Option 으로 교체
- 기존 filter.ts 임포트 참조 일괄 수정
- shared/types/filter/filter.ts 삭제

## 🔍 Describe

기존에 shared/types/filter/filter.ts에서 범용 UI 타입(Option)과 API 응답 타입(DomainResponse, FieldRoleItemResponse)이 혼재되어 있던 상황이었습니다.
이는 파일명이 내용을 설명하지 못하고, entity 책임의 타입이 shared 계층에 위치해 FSD 원칙에 어긋나는 상황이었습니다. 따라서 이번 PR에서는 여러 도메인에서 재사용되는 개념은 개념 기반 entity로, 범용 UI 타입은 shared로 책임을 정리했습니다.

참고로 지금까지는 @entities/post-create 등 페이지 기반 네이밍을 사용했으나, domain이나 field-role 같은 경우는 여러 페이지에서 재사용되는 도메인 개념이기 때문에, 이처럼 재사용이 잦은 개념은 @entities/domain, @entities/field-role 등 개념 기반 네이밍을 사용하기로 컨벤션을 정리했어요.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 공유 타입 정의를 통합하여 코드 일관성을 개선했습니다.
  * 중복 타입 정의를 제거하고 중앙화된 타입 시스템으로 마이그레이션했습니다.

**참고:** 이번 업데이트는 내부 코드 구조 개선으로, 사용자에게 보이는 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->