### PR TITLE
[Feat] 공고 수정하기 페이지 뷰 구현

### DIFF
--- a/src/entities/post-edit/api/types.ts
+++ b/src/entities/post-edit/api/types.ts
@@ -1,0 +1,41 @@
+import type { SuccessResponse } from '@shared/api/types';
+import type { TeamCulture } from '@shared/utils/team-culture/types';
+
+export interface PostDetailLeaderResponse {
+  userId: number;
+  username: string;
+  userImageUrl: string | null;
+}
+
+export interface PostDetailDomainResponse {
+  id: number;
+  name: string;
+}
+
+export interface PostDetailRoleResponse {
+  roleId: number;
+  roleName: string;
+  count: number;
+}
+
+export interface PostDetailResponse {
+  postId: number;
+  leader: PostDetailLeaderResponse;
+  title: string;
+  dday: number;
+  domains: PostDetailDomainResponse[];
+  recruitPeriod: {
+    startDate: string;
+    endDate: string;
+  };
+  homepageUrl: string;
+  contact: string;
+  currentRoles: PostDetailRoleResponse[];
+  recruitRoles: PostDetailRoleResponse[];
+  seeking: string;
+  aboutUs: string;
+  teamCulture: TeamCulture;
+  imageUrl: string;
+}
+
+export type GetPostDetailResponse = SuccessResponse<PostDetailResponse>;

--- a/src/entities/post-edit/model/adapters.ts
+++ b/src/entities/post-edit/model/adapters.ts
@@ -1,0 +1,45 @@
+import type { PostFormValues } from '@entities/posts/model/post-form/post-form';
+
+import type {
+  PostDetailLeaderResponse,
+  PostDetailResponse,
+  PostDetailRoleResponse,
+} from '../api/types';
+
+export interface PostDetailLeader {
+  userId: number;
+  username: string;
+  userImageUrl: string | null;
+}
+
+const toLeader = (leader: PostDetailLeaderResponse): PostDetailLeader => ({
+  userId: leader.userId,
+  username: leader.username,
+  userImageUrl: leader.userImageUrl,
+});
+
+const toRoleCountValues = (roles: PostDetailRoleResponse[]) =>
+  roles.map(({ roleId, count }) => ({ roleId, count }));
+
+export const toPostFormValues = (
+  detail: PostDetailResponse,
+): PostFormValues => ({
+  title: detail.title,
+  domainIds: detail.domains.map((domain) => domain.id),
+  recruitPeriod: detail.recruitPeriod,
+  homepageUrl: detail.homepageUrl,
+  contact: detail.contact,
+  currentRoles: toRoleCountValues(detail.currentRoles),
+  recruitRoles: toRoleCountValues(detail.recruitRoles),
+  seeking: detail.seeking,
+  aboutUs: detail.aboutUs,
+  teamCulture: detail.teamCulture,
+  image: {
+    file: null,
+    previewUrl: detail.imageUrl,
+  },
+});
+
+export const toPostDetailLeader = (
+  detail: PostDetailResponse,
+): PostDetailLeader => toLeader(detail.leader);

--- a/src/pages/post-create/post-create.tsx
+++ b/src/pages/post-create/post-create.tsx
@@ -37,6 +37,7 @@ const PostCreatePage = () => {
             // TODO: POST /api/posts 연결
             console.log(formValues);
           }}
+          submitLabel='업로드'
         />
       </main>
     </>

--- a/src/pages/post-edit/mock/mock-post-edit.ts
+++ b/src/pages/post-edit/mock/mock-post-edit.ts
@@ -1,0 +1,48 @@
+import type { PostDetailResponse } from '@entities/post-edit/api/types';
+
+export const MOCK_POST_EDIT: PostDetailResponse = {
+  postId: 100051,
+  leader: {
+    userId: 30001,
+    username: '슬찬',
+    userImageUrl: null,
+  },
+  title:
+    '일상 엔지니어링 문제를 해결할 "미래 모빌리티 해커톤" 팀원 모집합니다!',
+  dday: 4,
+  domains: [
+    { id: 1, name: 'IT' },
+    { id: 2, name: '디자인' },
+  ],
+  recruitPeriod: {
+    startDate: '2026-01-19',
+    endDate: '2026-03-12',
+  },
+  homepageUrl: 'www.linkareer.com',
+  contact: 'user_30001.gmail.com',
+  currentRoles: [
+    { roleId: 101, roleName: 'Content Marketer', count: 2 },
+    { roleId: 102, roleName: 'Social Media Marketer', count: 3 },
+    { roleId: 103, roleName: 'Digital Marketer', count: 1 },
+  ],
+  recruitRoles: [
+    { roleId: 104, roleName: 'Copywriter', count: 1 },
+    { roleId: 105, roleName: 'PR/Marketing Planner', count: 1 },
+    { roleId: 106, roleName: 'Brand Manager', count: 1 },
+  ],
+  seeking:
+    '저희 팀은 현재 모바일 앱 개발자 1명, 임베디드/하드웨어 엔지니어 1명, QA/기술 지원 1명을 긴급히 모집하고 있습니다.',
+  aboutUs:
+    '저희 팀은 일상 생활에서 발생하는 다양한 엔지니어링 문제를 미래 모빌리티 기술을 통해 해결하는 해커톤에 참가하고 있습니다.',
+  teamCulture: {
+    A: 1,
+    B: 0,
+    F: 0,
+    I: 0,
+    L: 1,
+  },
+  imageUrl: 'https://example.com/image.png',
+};
+
+// 로컬 테스트용 - 현재 유저가 작성자인 경우와 아닌 경우를 전환해서 확인
+export const MOCK_CURRENT_USER_ID = 30001;

--- a/src/pages/post-edit/post-edit.css.ts
+++ b/src/pages/post-edit/post-edit.css.ts
@@ -1,0 +1,33 @@
+import { style } from '@vanilla-extract/css';
+
+export const headerContainer = style({
+  display: 'flex',
+  marginTop: '4.8rem',
+  padding: '0 2rem',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      padding: '0 8rem',
+    },
+    'screen and (min-width: 1440px)': {
+      padding: '0 15rem',
+    },
+  },
+});
+
+export const pageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3.1rem',
+  width: '100%',
+  maxWidth: '124rem',
+  margin: '0 auto',
+  padding: '0 2rem 4rem',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      padding: '0 6rem 4rem',
+    },
+    'screen and (min-width: 1440px)': {
+      padding: '0 10rem 4rem',
+    },
+  },
+});

--- a/src/pages/post-edit/post-edit.tsx
+++ b/src/pages/post-edit/post-edit.tsx
@@ -1,5 +1,65 @@
+import {
+  toPostDetailLeader,
+  toPostFormValues,
+} from '@entities/post-edit/model/adapters';
+import { MOCK_DOMAIN_OPTIONS } from '@pages/post-create/mocks/mock-post-create-options';
+import {
+  MOCK_ALL_ROLE_OPTIONS,
+  MOCK_ROLE_FIELDS,
+  MOCK_ROLES_BY_FIELD_OPTIONS,
+} from '@pages/post-create/mocks/mock-post-role-options';
+import { ROUTE_PATH } from '@shared/constants/path';
+import PageBackHeader from '@widgets/page-back-header/page-back-header';
+import PostFormContent from '@widgets/post-form/post-form-content';
+import { useState } from 'react';
+
+import * as styles from './/post-edit.css';
+import { MOCK_CURRENT_USER_ID, MOCK_POST_EDIT } from './mock/mock-post-edit';
+
 const PostEditPage = () => {
-  return <div>PostEditPage</div>;
+  // TODO: useParams 등으로 postId 받아서 GET /api/posts/:postId 호출
+  const postDetail = MOCK_POST_EDIT;
+  const currentUserId = MOCK_CURRENT_USER_ID;
+
+  const leader = toPostDetailLeader(postDetail);
+  const isAuthor = leader.userId === currentUserId;
+
+  const [formValues, setFormValues] = useState(toPostFormValues(postDetail));
+
+  if (!isAuthor) {
+    // TODO: 권한 없음 처리 - 리다이렉트 또는 에러 페이지
+    return null;
+  }
+
+  const handleSubmit = () => {
+    // TODO: PATCH /api/posts/:postId 연결
+    console.log(formValues);
+  };
+
+  return (
+    <>
+      <section className={styles.headerContainer}>
+        <PageBackHeader
+          title='공고 수정'
+          backLabel='목록으로'
+          fallbackPath={ROUTE_PATH.POSTS}
+        />
+      </section>
+
+      <main className={styles.pageContainer}>
+        <PostFormContent
+          values={formValues}
+          onChange={setFormValues}
+          domainOptions={MOCK_DOMAIN_OPTIONS}
+          roleFields={MOCK_ROLE_FIELDS}
+          rolesByFieldOptions={MOCK_ROLES_BY_FIELD_OPTIONS}
+          allRoleOptions={MOCK_ALL_ROLE_OPTIONS}
+          onSubmit={handleSubmit}
+          submitLabel='수정하기'
+        />
+      </main>
+    </>
+  );
 };
 
 export default PostEditPage;

--- a/src/pages/post-edit/post-edit.tsx
+++ b/src/pages/post-edit/post-edit.tsx
@@ -13,7 +13,7 @@ import PageBackHeader from '@widgets/page-back-header/page-back-header';
 import PostFormContent from '@widgets/post-form/post-form-content';
 import { useState } from 'react';
 
-import * as styles from './/post-edit.css';
+import * as styles from './post-edit.css';
 import { MOCK_CURRENT_USER_ID, MOCK_POST_EDIT } from './mock/mock-post-edit';
 
 const PostEditPage = () => {

--- a/src/pages/post-edit/post-edit.tsx
+++ b/src/pages/post-edit/post-edit.tsx
@@ -13,8 +13,8 @@ import PageBackHeader from '@widgets/page-back-header/page-back-header';
 import PostFormContent from '@widgets/post-form/post-form-content';
 import { useState } from 'react';
 
-import * as styles from './post-edit.css';
 import { MOCK_CURRENT_USER_ID, MOCK_POST_EDIT } from './mock/mock-post-edit';
+import * as styles from './post-edit.css';
 
 const PostEditPage = () => {
   // TODO: useParams 등으로 postId 받아서 GET /api/posts/:postId 호출

--- a/src/widgets/post-form/post-form-content.tsx
+++ b/src/widgets/post-form/post-form-content.tsx
@@ -33,6 +33,7 @@ interface PostFormContentProps {
   rolesByFieldOptions: Record<number, Option[]>;
   allRoleOptions: Option[];
   onSubmit: () => void;
+  submitLabel: string;
 }
 
 const PostFormContent = ({
@@ -43,6 +44,7 @@ const PostFormContent = ({
   rolesByFieldOptions,
   allRoleOptions,
   onSubmit,
+  submitLabel,
 }: PostFormContentProps) => {
   const [pendingCurrentRole, setPendingCurrentRole] =
     useState<PendingRoleInput>(createEmptyPendingRoleInput());
@@ -161,7 +163,7 @@ const PostFormContent = ({
 
       <div className={styles.submitContainer}>
         <CtaButton color='primary' onClick={onSubmit}>
-          업로드
+          {submitLabel}
         </CtaButton>
       </div>
     </>


### PR DESCRIPTION
## 📌 Summary

> #85 
공고 수정하기 페이지 뷰 구현

## 📚 Tasks

- API 원본 타입 및 adapters 정의
- `PostFormContent` 에 submitLabel prop 추가 (req)
- 공고 수정하기 페이지 뷰 구현

## 🔍 Describe

공고 작성하기 페이지와 수정하기 페이지는 동일한 UI를 공유하므로 지난 공고 작성하기 페이지에서 생성한 PostFormContent를 그대로 사용하되, 상태 초기화 방식에만 차이를 두었습니다. 작성 페이지는 `createEmptyPostFormValues()`로 초기화를 진행하고, 수정 페이지는 GET 응답 -> adapters를 거쳐 `PostFormValues`로 초기화합니다.

submitLabel을 새로 추가했는데, optional + fallback으로 하는 것보다 이 편이 기본값에 의존하지 않게 되어 더 적합하다고 판단해 required prop으로 두었어요.

현재는 auth 전역 상태가 없어  `MOCK_CURRENT_USER_ID`와 `leader.userId`를 비교하는 방식으로 뼈대만 잡았습니다. 추후 JWT Access Token payload에서 `userId`를 읽어오는 방식으로 교체할 예정입니다. `isAuthor`가 `false`인 경우 `null`을 반환하며, 추후 리다이렉트 또는 에러 페이지로 교체합니다.

GET 응답의 `imageUrl`(S3 URL 문자열)은 `previewUrl`에만 세팅하고 `file`은 `null`로 초기화했습니다. 수정 제출 시 `file`이 `null`이면 기존 `imageKey`를 그대로 사용하는 분기는 PATCH API 연결 시점에 처리할 예정입니다.


## 👀 To Reviewer
목데이터간 일치하지 않는 경우가 있으나(id, name) 추후 API 연결 작업 예정이기 때문에 따로 수정을 거치지는 않았어요. 로컬 테스트는 전부 마쳤습니다! 

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 수정 페이지가 추가되어 기존 게시물을 불러와 편집할 수 있습니다.
  * 편집 가능한 폼이 게시물 상세 데이터를 기반으로 초기화됩니다.
  * 작성자만 수정 화면에 접근하도록 제한됩니다.
  * 로컬용 모의 게시물 데이터가 포함되어 테스트가 용이해졌습니다.

* **개선 사항**
  * 제출 버튼 레이블을 동적으로 설정할 수 있게 되었습니다.
  * 편집 페이지 레이아웃 및 스타일이 반응형으로 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->