### PR TITLE
[Feat] 로그인 페이지 뷰 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/pages/login/login.css.ts
+++ b/src/pages/login/login.css.ts
@@ -1,0 +1,88 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const pageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100vh',
+  background: 'linear-gradient(to bottom, #ffffff 50%, #e6f7f2 100%)',
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  maxWidth: '53rem',
+  margin: '0 auto',
+  padding: '0 2rem',
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '3.2rem',
+  paddingBottom: '6rem',
+});
+
+export const logo = style({
+  color: themeVars.color.primary,
+  ...themeVars.font.display_36b,
+});
+
+export const formContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3.3rem',
+});
+
+export const titleContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.8rem',
+});
+
+export const title = style({
+  color: themeVars.color.gray_900,
+  ...themeVars.font.title_28sb,
+});
+
+export const subtitle = style({
+  color: themeVars.color.gray_500,
+  ...themeVars.font.body_16sb,
+});
+
+export const fieldContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '3rem',
+});
+
+export const fieldWrapper = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+});
+
+export const errorText = style({
+  color: themeVars.color.negative,
+  ...themeVars.font.body_14r,
+});
+
+export const divider = style({
+  width: '100%',
+  height: '1px',
+  backgroundColor: themeVars.color.gray_200,
+});
+
+export const signUpContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  gap: '1.2rem',
+});
+
+export const signUpText = style({
+  marginBottom: '0.4rem',
+  color: themeVars.color.gray_400,
+  ...themeVars.font.body_18r,
+});

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -28,7 +28,6 @@ const LoginPage = () => {
 
     // TODO: POST /api/auth/login 연결
     // 아래는 뼈대 - 실제 API 연결 시 교체
-    console.log(formValues);
 
     // API 연결 후 아래 패턴으로 처리:
     // const response = await fetch('/api/auth/login', {
@@ -73,6 +72,7 @@ const LoginPage = () => {
           <div className={styles.fieldContainer}>
             <div className={styles.fieldWrapper}>
               <TextField
+                name='loginId'
                 value={formValues.loginId}
                 onChange={(e) =>
                   setFormValues({ ...formValues, loginId: e.target.value })
@@ -84,6 +84,7 @@ const LoginPage = () => {
               )}
 
               <TextField
+                name='password'
                 value={formValues.password}
                 onChange={(e) =>
                   setFormValues({ ...formValues, password: e.target.value })
@@ -93,7 +94,7 @@ const LoginPage = () => {
               />
             </div>
 
-            <CtaButton color='primary' onClick={handleSubmit}>
+            <CtaButton color='primary' onClick={handleSubmit} type='submit'>
               로그인
             </CtaButton>
           </div>
@@ -102,7 +103,7 @@ const LoginPage = () => {
 
           <div className={styles.signUpContainer}>
             <p className={styles.signUpText}>계정이 없으신가요?</p>
-            <CtaButton color='gray' onClick={handleClickSignUp}>
+            <CtaButton color='gray' onClick={handleClickSignUp} type='button'>
               회원가입
             </CtaButton>
           </div>

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -1,5 +1,115 @@
+import { ROUTE_PATH } from '@shared/constants/path';
+import CtaButton from '@shared/ui/components/cta-button/cta-button';
+import TextField from '@shared/ui/components/field/textfield/textfield';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import * as styles from './login.css';
+
+interface LoginFormValues {
+  loginId: string;
+  password: string;
+}
+
+const createEmptyLoginFormValues = (): LoginFormValues => ({
+  loginId: '',
+  password: '',
+});
+
 const LoginPage = () => {
-  return <div>LoginPage</div>;
+  const navigate = useNavigate();
+  const [formValues, setFormValues] = useState<LoginFormValues>(
+    createEmptyLoginFormValues(),
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setErrorMessage(null);
+
+    // TODO: POST /api/auth/login 연결
+    // 아래는 뼈대 - 실제 API 연결 시 교체
+    console.log(formValues);
+
+    // API 연결 후 아래 패턴으로 처리:
+    // const response = await fetch('/api/auth/login', {
+    //   method: 'POST',
+    //   headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    //   body: new URLSearchParams(formValues),
+    //   credentials: 'include',
+    // });
+    //
+    // if (response.status === 401) {
+    //   setErrorMessage('이메일 또는 비밀번호를 확인해주세요.');
+    //   return;
+    // }
+    //
+    // const accessToken = response.headers.get('Authorization');
+    // if (accessToken != null) {
+    //   setAccessToken(accessToken.replace('Bearer ', ''));
+    // }
+    //
+    // navigate(ROUTE_PATH.POSTS);
+  };
+
+  const handleClickSignUp = () => {
+    navigate(ROUTE_PATH.SIGN_UP);
+  };
+
+  return (
+    <div className={styles.pageContainer}>
+      <div className={styles.contentContainer}>
+        <header className={styles.header}>
+          <span className={styles.logo}>UniON</span>
+        </header>
+
+        <div className={styles.formContainer}>
+          <div className={styles.titleContainer}>
+            <p className={styles.title}>로그인</p>
+            <p className={styles.subtitle}>
+              UniON에서 나와 핏한 팀원들을 쉽게 찾아보세요.
+            </p>
+          </div>
+
+          <div className={styles.fieldContainer}>
+            <div className={styles.fieldWrapper}>
+              <TextField
+                value={formValues.loginId}
+                onChange={(e) =>
+                  setFormValues({ ...formValues, loginId: e.target.value })
+                }
+                placeholder='이메일'
+              />
+              {errorMessage != null && (
+                <p className={styles.errorText}>{errorMessage}</p>
+              )}
+
+              <TextField
+                value={formValues.password}
+                onChange={(e) =>
+                  setFormValues({ ...formValues, password: e.target.value })
+                }
+                placeholder='비밀번호'
+                type='password'
+              />
+            </div>
+
+            <CtaButton color='primary' onClick={handleSubmit}>
+              로그인
+            </CtaButton>
+          </div>
+
+          <div className={styles.divider} />
+
+          <div className={styles.signUpContainer}>
+            <p className={styles.signUpText}>계정이 없으신가요?</p>
+            <CtaButton color='gray' onClick={handleClickSignUp}>
+              회원가입
+            </CtaButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/src/shared/api/auth-client.ts
+++ b/src/shared/api/auth-client.ts
@@ -1,0 +1,78 @@
+import { ENV } from '@shared/constants/env';
+import {
+  clearAccessToken,
+  getAccessToken,
+  setAccessToken,
+} from '@shared/utils/auth/token';
+
+const REFRESH_URL = `${ENV.API_BASE_URL}/auth/refresh`;
+
+interface RequestOptions extends RequestInit {
+  skipAuth?: boolean;
+}
+
+const fetchWithAuth = async (
+  url: string,
+  options: RequestOptions = {},
+): Promise<Response> => {
+  const { skipAuth = false, ...fetchOptions } = options;
+
+  const headers = new Headers(fetchOptions.headers);
+
+  if (!skipAuth) {
+    const token = getAccessToken();
+    if (token != null) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+  }
+
+  const response = await fetch(`${ENV.API_BASE_URL}${url}`, {
+    ...fetchOptions,
+    headers,
+  });
+
+  if (response.status === 401 && !skipAuth) {
+    const refreshed = await tryRefreshToken();
+
+    if (!refreshed) {
+      clearAccessToken();
+      window.location.href = '/login';
+      return response;
+    }
+
+    const newToken = getAccessToken();
+    if (newToken != null) {
+      headers.set('Authorization', `Bearer ${newToken}`);
+    }
+
+    return fetch(`${ENV.API_BASE_URL}${url}`, { ...fetchOptions, headers });
+  }
+
+  return response;
+};
+
+const tryRefreshToken = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(REFRESH_URL, {
+      method: 'POST',
+      credentials: 'include',
+    });
+
+    if (!response.ok) {
+      return false;
+    }
+
+    const newAccessToken = response.headers.get('Authorization');
+
+    if (newAccessToken == null) {
+      return false;
+    }
+
+    setAccessToken(newAccessToken.replace('Bearer ', ''));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export default fetchWithAuth;

--- a/src/shared/api/auth-client.ts
+++ b/src/shared/api/auth-client.ts
@@ -1,4 +1,5 @@
 import { ENV } from '@shared/constants/env';
+import { ROUTE_PATH } from '@shared/constants/path';
 import {
   clearAccessToken,
   getAccessToken,
@@ -36,8 +37,8 @@ const fetchWithAuth = async (
 
     if (!refreshed) {
       clearAccessToken();
-      window.location.href = '/login';
-      return response;
+      window.location.href = ROUTE_PATH.LOGIN;
+      throw new Error('Unauthorized: redirecting to /login');
     }
 
     const newToken = getAccessToken();
@@ -51,7 +52,19 @@ const fetchWithAuth = async (
   return response;
 };
 
-const tryRefreshToken = async (): Promise<boolean> => {
+let refreshPromise: Promise<boolean> | null = null;
+
+const tryRefreshToken = (): Promise<boolean> => {
+  if (refreshPromise != null) {
+    return refreshPromise;
+  }
+  refreshPromise = doRefresh().finally(() => {
+    refreshPromise = null;
+  });
+  return refreshPromise;
+};
+
+const doRefresh = async (): Promise<boolean> => {
   try {
     const response = await fetch(REFRESH_URL, {
       method: 'POST',

--- a/src/shared/constants/env.ts
+++ b/src/shared/constants/env.ts
@@ -1,0 +1,3 @@
+export const ENV = {
+  API_BASE_URL: import.meta.env.VITE_API_BASE_URL,
+} as const;

--- a/src/shared/ui/components/cta-button/cta-button.tsx
+++ b/src/shared/ui/components/cta-button/cta-button.tsx
@@ -7,12 +7,19 @@ interface CtaButtonProps {
   children: ReactNode;
   disabled?: boolean;
   onClick: () => void;
+  type?: 'button' | 'submit';
 }
 
-const CtaButton = ({ color, children, disabled, onClick }: CtaButtonProps) => {
+const CtaButton = ({
+  color,
+  children,
+  disabled,
+  onClick,
+  type = 'button',
+}: CtaButtonProps) => {
   return (
     <button
-      type='button'
+      type={type}
       disabled={disabled}
       onClick={onClick}
       className={styles.base({ color })}

--- a/src/shared/utils/auth/token.ts
+++ b/src/shared/utils/auth/token.ts
@@ -1,0 +1,33 @@
+import type { TokenPayload } from './types';
+
+let accessToken: string | null = null;
+
+export const setAccessToken = (token: string): void => {
+  accessToken = token;
+};
+
+export const getAccessToken = (): string | null => {
+  return accessToken;
+};
+
+export const clearAccessToken = (): void => {
+  accessToken = null;
+};
+
+export const decodeTokenPayload = <T>(token: string): T | null => {
+  try {
+    const payload = token.split('.')[1];
+    return JSON.parse(atob(payload)) as T;
+  } catch {
+    return null;
+  }
+};
+
+export const getCurrentUserId = (): number | null => {
+  if (accessToken == null) {
+    return null;
+  }
+
+  const payload = decodeTokenPayload<TokenPayload>(accessToken);
+  return payload != null ? payload.userId : null;
+};

--- a/src/shared/utils/auth/token.ts
+++ b/src/shared/utils/auth/token.ts
@@ -17,7 +17,21 @@ export const clearAccessToken = (): void => {
 export const decodeTokenPayload = <T>(token: string): T | null => {
   try {
     const payload = token.split('.')[1];
-    return JSON.parse(atob(payload)) as T;
+
+    if (payload == null) {
+      return null;
+    }
+
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const remainder = base64.length % 4;
+    const padded =
+      remainder === 0 ? base64 : base64 + '==='.slice(0, 4 - remainder);
+
+    const binary = atob(padded);
+    const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+    const json = new TextDecoder('utf-8').decode(bytes);
+
+    return JSON.parse(json) as T;
   } catch {
     return null;
   }

--- a/src/shared/utils/auth/types.ts
+++ b/src/shared/utils/auth/types.ts
@@ -1,0 +1,4 @@
+export interface TokenPayload {
+  userId: number;
+  // 실제 payload 필드 확인 후 추가 예정
+}


### PR DESCRIPTION
## 📌 Summary

> #87 
로그인 페이지 뷰 구현

## 📚 Tasks

- 로그인 페이지 뷰 구현
- `token.ts` : 액세스 토큰 메모리 저장, 디코딩, userId 추출 유틸
- `types.ts` : TokenPayload 타입 (실제 페이로드 확인 후 필드 추가 필요) 
- `auth-client.ts` : 토큰 자동 첨부 + 만료 시 refresh/retry
- 환경변수 상수화   

## 🔍 Describe

로그인 페이지를 작업하며 API 연결을 위한 기초 작업들을 진행했어요. 

### JWT 기반 인증 구조

로그인 성공 시 서버가 응답 헤더(`Authorization: Bearer <token>`)로 내려주는 Access Token을 모듈 스코프 변수(메모리)에 저장합니다. Refresh Token은 서버가 `Set-Cookie`로 내려주므로 프론트에서 별도 처리 없이 브라우저 쿠키에 자동 저장됩니다.

- **Access Token**: 30분 유효, 메모리 저장 (`token.ts`)
- **Refresh Token**: 2주 유효, 브라우저 쿠키 자동 저장
- **새로고침 시 복구**: 메모리가 초기화되므로 앱 진입 시점에 `/api/auth/refresh`를 호출해 Access Token을 재발급받는 로직이 추후 필요합니다. 라우터 구조 확정 후 연결할 예정입니다.


### fetchWithAuth

모든 인증이 필요한 API 요청에 사용할 fetch 래퍼입니다.

1. 요청 시 `Authorization: Bearer <token>` 헤더 자동 첨부
2. 401 응답 시 `/api/auth/refresh`로 토큰 재발급 시도 (`credentials: 'include'`로 쿠키 자동 포함)
3. 재발급 성공 시 원래 요청 재시도, 실패 시 `/login`으로 redirect

Tanstack Query의 `queryFn` / `mutationFn` 안에서 `fetchWithAuth`를 그대로 사용하면 되므로 추후 API 연결 시 Query 쪽 코드는 별도 인터셉터 없이 깔끔하게 유지됩니다.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 로그인 페이지가 추가되었습니다. 로그인 ID, 비밀번호 입력 필드와 회원가입 이동 기능을 포함합니다.
  * 인증 시스템이 추가되었습니다. 자동 토큰 갱신 및 세션 관리 기능을 지원합니다.

* **기타**
  * 환경 설정 파일이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->