### PR TITLE
[Feat] 회원가입 페이지 뷰 작업

### DIFF
--- a/src/entities/signup/api/types.ts
+++ b/src/entities/signup/api/types.ts
@@ -1,0 +1,33 @@
+import type { SuccessResponse } from '@shared/api/types';
+import type { AcademicStatusKey } from '@shared/utils/academic-status/types';
+import type { Personality } from '@shared/utils/personality/types';
+
+export interface SignupRequest {
+  loginId: string;
+  password: string;
+  email: string;
+  username: string;
+  birthYear: number | null;
+  gender: string | null;
+  mainRoleId: number | null;
+  universityId: number | null;
+  major: string;
+  entranceYear: number | null;
+  status: AcademicStatusKey | null;
+  personality: Personality;
+}
+
+export interface SignupResponseData {
+  userId: number;
+  loginId: string;
+  username: string;
+}
+
+export type SignupResponse = SuccessResponse<SignupResponseData>;
+
+export interface UsernameCheckResponseData {
+  username: string;
+  available: boolean;
+}
+
+export type UsernameCheckResponse = SuccessResponse<UsernameCheckResponseData>;

--- a/src/entities/signup/api/types.ts
+++ b/src/entities/signup/api/types.ts
@@ -2,18 +2,20 @@ import type { SuccessResponse } from '@shared/api/types';
 import type { AcademicStatusKey } from '@shared/utils/academic-status/types';
 import type { Personality } from '@shared/utils/personality/types';
 
+export type Gender = 'MALE' | 'FEMALE' | 'NOT_SPECIFIED';
+
 export interface SignupRequest {
   loginId: string;
   password: string;
   email: string;
   username: string;
-  birthYear: number | null;
-  gender: string | null;
-  mainRoleId: number | null;
-  universityId: number | null;
+  birthYear: number;
+  gender: Gender;
+  mainRoleId: number;
+  universityId: number;
   major: string;
-  entranceYear: number | null;
-  status: AcademicStatusKey | null;
+  entranceYear: number;
+  status: AcademicStatusKey;
   personality: Personality;
 }
 

--- a/src/entities/signup/model/signup-form.ts
+++ b/src/entities/signup/model/signup-form.ts
@@ -1,0 +1,39 @@
+import type { AcademicStatusKey } from '@shared/utils/academic-status/types';
+import type { Personality } from '@shared/utils/personality/types';
+
+export interface SignupFormValues {
+  // Step1
+  loginId: string;
+  password: string;
+  email: string;
+  username: string;
+  birthYear: string;
+  gender: string | null;
+  // Step2
+  mainRoleId: number | null;
+  mainRoleFieldId: number | null;
+  universityId: number | null;
+  universityName: string;
+  major: string;
+  entranceYear: string;
+  status: AcademicStatusKey | null;
+  // Step3
+  personality: Partial<Personality>;
+}
+
+export const createEmptySignupFormValues = (): SignupFormValues => ({
+  loginId: '',
+  password: '',
+  email: '',
+  username: '',
+  birthYear: '',
+  gender: null,
+  mainRoleId: null,
+  mainRoleFieldId: null,
+  universityId: null,
+  universityName: '',
+  major: '',
+  entranceYear: '',
+  status: null,
+  personality: {},
+});

--- a/src/pages/signup/mock/mock-signup-roles.ts
+++ b/src/pages/signup/mock/mock-signup-roles.ts
@@ -1,0 +1,32 @@
+import type { Option } from '@shared/types/common';
+
+export const SIGNUP_ROLE_FIELDS: Option[] = [
+  { id: 1, name: '기획' },
+  { id: 2, name: '디자인' },
+  { id: 3, name: '개발' },
+  { id: 4, name: '마케팅' },
+];
+
+export const SIGNUP_ROLES_BY_FIELD: Record<number, Option[]> = {
+  1: [
+    { id: 101, name: 'PM' },
+    { id: 102, name: '서비스 기획자' },
+    { id: 103, name: '사업 기획자' },
+  ],
+  2: [
+    { id: 201, name: 'UX 디자이너' },
+    { id: 202, name: 'UI 디자이너' },
+    { id: 203, name: 'BX 디자이너' },
+  ],
+  3: [
+    { id: 301, name: '프론트엔드 개발자' },
+    { id: 302, name: '백엔드 개발자' },
+    { id: 303, name: 'AI 엔지니어' },
+    { id: 304, name: 'iOS 개발자' },
+    { id: 305, name: 'Android 개발자' },
+  ],
+  4: [
+    { id: 401, name: '콘텐츠 마케터' },
+    { id: 402, name: '퍼포먼스 마케터' },
+  ],
+};

--- a/src/pages/signup/mock/mock-signup-universities.ts
+++ b/src/pages/signup/mock/mock-signup-universities.ts
@@ -1,0 +1,12 @@
+import type { UniversityOption } from '@shared/ui/components/dropdown/dropdown-content/university-content';
+
+export const MOCK_UNIVERSITIES: UniversityOption[] = [
+  { id: 101, name: '가야대학교(고령)' },
+  { id: 102, name: '가야대학교(김해)' },
+  { id: 103, name: '가천대학교' },
+  { id: 104, name: '가톨릭관동대학교' },
+  { id: 105, name: '연세대학교' },
+  { id: 106, name: '이화여자대학교' },
+  { id: 107, name: '서울대학교' },
+  { id: 108, name: '감리교신학대학교' },
+];

--- a/src/pages/signup/signup.css.ts
+++ b/src/pages/signup/signup.css.ts
@@ -1,0 +1,47 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const pageContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: '100vh',
+  background: 'linear-gradient(to bottom, #ffffff 50%, #e6f7f2 100%)',
+});
+
+export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: '100%',
+  maxWidth: '53rem',
+  margin: '0 auto',
+  padding: '0 2rem 4rem',
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'center',
+  paddingTop: '3.2rem',
+  paddingBottom: '2.4rem',
+});
+
+export const logo = style({
+  color: themeVars.color.primary,
+  ...themeVars.font.display_36b,
+});
+
+export const titleContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.8rem',
+  marginBottom: '2.4rem',
+});
+
+export const title = style({
+  ...themeVars.font.title_28sb,
+  color: themeVars.color.gray_900,
+});
+
+export const subtitle = style({
+  ...themeVars.font.body_16sb,
+  color: themeVars.color.gray_400,
+});

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -1,5 +1,112 @@
+// pages/signup/signup-page.tsx
+
+import { createEmptySignupFormValues } from '@entities/signup/model/signup-form';
+import { ROUTE_PATH } from '@shared/constants/path';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import {
+  SIGNUP_ROLE_FIELDS,
+  SIGNUP_ROLES_BY_FIELD,
+} from './mock/mock-signup-roles';
+import { MOCK_UNIVERSITIES } from './mock/mock-signup-universities';
+import * as styles from './signup.css';
+import SignupComplete from './ui/signup-complete/signup-complete';
+import SignupProgress from './ui/signup-progress/signup-progress';
+import SignupStep1 from './ui/signup-step1/signup-step1';
+import SignupStep2 from './ui/signup-step2/signup-step2';
+import SignupStep3 from './ui/signup-step3/signup-step3';
+
+type SignupStep = 1 | 2 | 3 | 'complete';
+
 const SignupPage = () => {
-  return <div>SignupPage</div>;
+  const navigate = useNavigate();
+  const [step, setStep] = useState<SignupStep>(1);
+  const [formValues, setFormValues] = useState(createEmptySignupFormValues());
+  const [isUsernameChecked, setIsUsernameChecked] = useState(false);
+  const [universityOptions, setUniversityOptions] = useState(MOCK_UNIVERSITIES);
+
+  const handleCheckUsername = () => {
+    // TODO: GET /api/auth/username?q=:username 연결
+    console.log('중복확인:', formValues.username);
+    setIsUsernameChecked(true);
+  };
+
+  const handleSearchUniversity = (query: string) => {
+    // TODO: GET /api/university?q=:query 연결
+    const filtered = MOCK_UNIVERSITIES.filter((u) => u.name.includes(query));
+    setUniversityOptions(filtered);
+  };
+
+  const handleSubmit = () => {
+    // TODO: POST /api/auth/signup 연결
+    console.log(formValues);
+    setStep('complete');
+  };
+
+  const handleStart = () => {
+    navigate(ROUTE_PATH.POSTS);
+  };
+
+  const handleUsernameChange = (next: typeof formValues) => {
+    if (next.username !== formValues.username) {
+      setIsUsernameChecked(false);
+    }
+    setFormValues(next);
+  };
+
+  return (
+    <div className={styles.pageContainer}>
+      <div className={styles.contentContainer}>
+        <header className={styles.header}>
+          <span className={styles.logo}>UniON</span>
+        </header>
+
+        {step !== 'complete' && <SignupProgress currentStep={step} />}
+        {step === 'complete' && <SignupProgress currentStep={3} />}
+
+        <div className={styles.titleContainer}>
+          <h1 className={styles.title}>
+            {step === 'complete' ? '회원가입 완료!' : '회원가입'}
+          </h1>
+          {step !== 'complete' && (
+            <p className={styles.subtitle}>
+              UniON에서 나와 핏한 팀원들을 쉽게 찾아보세요.
+            </p>
+          )}
+        </div>
+
+        {step === 1 && (
+          <SignupStep1
+            values={formValues}
+            onChange={handleUsernameChange}
+            isUsernameChecked={isUsernameChecked}
+            onCheckUsername={handleCheckUsername}
+            onNext={() => setStep(2)}
+          />
+        )}
+        {step === 2 && (
+          <SignupStep2
+            values={formValues}
+            onChange={setFormValues}
+            roleFields={SIGNUP_ROLE_FIELDS}
+            rolesByFieldOptions={SIGNUP_ROLES_BY_FIELD}
+            universityOptions={universityOptions}
+            onSearchUniversity={handleSearchUniversity}
+            onNext={() => setStep(3)}
+          />
+        )}
+        {step === 3 && (
+          <SignupStep3
+            values={formValues}
+            onChange={setFormValues}
+            onNext={handleSubmit}
+          />
+        )}
+        {step === 'complete' && <SignupComplete onStart={handleStart} />}
+      </div>
+    </div>
+  );
 };
 
 export default SignupPage;

--- a/src/pages/signup/ui/signup-complete/signup-complete.css.ts
+++ b/src/pages/signup/ui/signup-complete/signup-complete.css.ts
@@ -1,0 +1,23 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '4rem',
+});
+
+export const textContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.8rem',
+});
+
+export const description = style({
+  ...themeVars.font.body_14r,
+  color: themeVars.color.gray_500,
+});
+
+export const buttonContainer = style({
+  width: '100%',
+});

--- a/src/pages/signup/ui/signup-complete/signup-complete.tsx
+++ b/src/pages/signup/ui/signup-complete/signup-complete.tsx
@@ -1,0 +1,30 @@
+import CtaButton from '@shared/ui/components/cta-button/cta-button';
+
+import * as styles from './signup-complete.css';
+
+interface SignupCompleteProps {
+  onStart: () => void;
+}
+
+const SignupComplete = ({ onStart }: SignupCompleteProps) => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.textContainer}>
+        <p className={styles.description}>
+          설정한 프로필은 마이페이지에서 언제든 수정할 수 있어요.
+        </p>
+        <p className={styles.description}>
+          UniON에서 특별한 팀원들을 만나보세요.
+        </p>
+      </div>
+
+      <div className={styles.buttonContainer}>
+        <CtaButton color='primary' onClick={onStart}>
+          시작하기
+        </CtaButton>
+      </div>
+    </div>
+  );
+};
+
+export default SignupComplete;

--- a/src/pages/signup/ui/signup-progress/signup-progress.css.ts
+++ b/src/pages/signup/ui/signup-progress/signup-progress.css.ts
@@ -1,0 +1,44 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  justifyContent: 'center',
+  gap: '1.6rem',
+  marginBottom: '3.2rem',
+});
+
+const stepBase = style({
+  width: '2.4rem',
+  height: '2.4rem',
+  borderRadius: '50%',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
+export const stepDone = style([
+  stepBase,
+  {
+    backgroundColor: themeVars.color.primary,
+  },
+]);
+
+export const stepActive = style([
+  stepBase,
+  {
+    backgroundColor: themeVars.color.primary,
+  },
+]);
+
+export const stepIdle = style([
+  stepBase,
+  {
+    backgroundColor: themeVars.color.gray_200,
+  },
+]);
+
+export const ProgressCompletedIcon = style({
+  width: '1.4rem',
+  height: '1.4rem',
+});

--- a/src/pages/signup/ui/signup-progress/signup-progress.tsx
+++ b/src/pages/signup/ui/signup-progress/signup-progress.tsx
@@ -1,0 +1,37 @@
+import { ProgressCompletedIcon } from '@shared/assets/icons';
+
+import * as styles from './signup-progress.css';
+
+interface SignupProgressProps {
+  currentStep: 1 | 2 | 3;
+}
+
+const SignupProgress = ({ currentStep }: SignupProgressProps) => {
+  return (
+    <div className={styles.container}>
+      {([1, 2, 3] as const).map((step) => {
+        const isDone = step < currentStep;
+        const isActive = step === currentStep;
+
+        return (
+          <div
+            key={step}
+            className={
+              isDone
+                ? styles.stepDone
+                : isActive
+                  ? styles.stepActive
+                  : styles.stepIdle
+            }
+          >
+            {isDone && (
+              <ProgressCompletedIcon className={styles.ProgressCompletedIcon} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SignupProgress;

--- a/src/pages/signup/ui/signup-step1/signup-step1.css.ts
+++ b/src/pages/signup/ui/signup-step1/signup-step1.css.ts
@@ -1,0 +1,34 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2.4rem',
+});
+
+export const fieldList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+});
+
+export const usernameRow = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr auto',
+  gap: '0.8rem',
+  alignItems: 'center',
+});
+
+export const buttonContainer = style({
+  width: '100%',
+  marginTop: '1rem',
+});
+
+export const checkButton = style({
+  padding: '1.5rem 2rem',
+  backgroundColor: themeVars.color.primary,
+  color: themeVars.color.gray_000,
+  ...themeVars.font.body_18r,
+  borderRadius: '10px',
+});

--- a/src/pages/signup/ui/signup-step1/signup-step1.tsx
+++ b/src/pages/signup/ui/signup-step1/signup-step1.tsx
@@ -67,7 +67,6 @@ const SignupStep1 = ({
           />
           <button
             className={styles.checkButton}
-            color={values.username.trim() !== '' ? 'primary' : 'gray'}
             disabled={values.username.trim() === ''}
             onClick={onCheckUsername}
           >

--- a/src/pages/signup/ui/signup-step1/signup-step1.tsx
+++ b/src/pages/signup/ui/signup-step1/signup-step1.tsx
@@ -1,0 +1,110 @@
+import type { SignupFormValues } from '@entities/signup/model/signup-form';
+import CtaButton from '@shared/ui/components/cta-button/cta-button';
+import TextField from '@shared/ui/components/field/textfield/textfield';
+
+import SimpleSelect from '../simple-select/simple-select';
+import * as styles from './signup-step1.css';
+
+const GENDER_OPTIONS = [
+  { value: 'MALE', label: '남성' },
+  { value: 'FEMALE', label: '여성' },
+  { value: 'NOT_SPECIFIED', label: '선택 안함' },
+];
+
+interface SignupStep1Props {
+  values: SignupFormValues;
+  onChange: (next: SignupFormValues) => void;
+  isUsernameChecked: boolean;
+  onCheckUsername: () => void;
+  onNext: () => void;
+}
+
+const isStep1Complete = (
+  values: SignupFormValues,
+  isUsernameChecked: boolean,
+): boolean => {
+  return (
+    values.loginId.trim() !== '' &&
+    values.password.trim() !== '' &&
+    values.email.trim() !== '' &&
+    values.username.trim() !== '' &&
+    isUsernameChecked &&
+    values.birthYear.trim() !== '' &&
+    values.gender != null
+  );
+};
+
+const SignupStep1 = ({
+  values,
+  onChange,
+  isUsernameChecked,
+  onCheckUsername,
+  onNext,
+}: SignupStep1Props) => {
+  const isComplete = isStep1Complete(values, isUsernameChecked);
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.fieldList}>
+        <TextField
+          value={values.loginId}
+          onChange={(e) => onChange({ ...values, loginId: e.target.value })}
+          placeholder='이메일'
+        />
+        <TextField
+          value={values.password}
+          onChange={(e) => onChange({ ...values, password: e.target.value })}
+          placeholder='비밀번호'
+          type='password'
+        />
+        <div className={styles.usernameRow}>
+          <TextField
+            value={values.username}
+            onChange={(e) => {
+              onChange({ ...values, username: e.target.value });
+            }}
+            placeholder='닉네임'
+          />
+          <button
+            className={styles.checkButton}
+            color={values.username.trim() !== '' ? 'primary' : 'gray'}
+            disabled={values.username.trim() === ''}
+            onClick={onCheckUsername}
+          >
+            중복확인
+          </button>
+        </div>
+        <TextField
+          value={values.email}
+          onChange={(e) => onChange({ ...values, email: e.target.value })}
+          placeholder='연락용 이메일'
+          type='email'
+        />
+        <TextField
+          value={values.birthYear}
+          onChange={(e) => onChange({ ...values, birthYear: e.target.value })}
+          placeholder='출생연도 (예: 2000)'
+          type='number'
+        />
+        <SimpleSelect
+          options={GENDER_OPTIONS}
+          value={values.gender}
+          placeholder='성별'
+          onChange={(gender) => onChange({ ...values, gender })}
+        />
+      </div>
+
+      <div className={styles.buttonContainer}>
+        <CtaButton
+          color={isComplete ? 'primary' : 'gray'}
+          disabled={!isComplete}
+          onClick={onNext}
+        >
+          다음
+        </CtaButton>
+      </div>
+    </div>
+  );
+};
+
+export default SignupStep1;

--- a/src/pages/signup/ui/signup-step2/signup-step2.css.ts
+++ b/src/pages/signup/ui/signup-step2/signup-step2.css.ts
@@ -1,0 +1,18 @@
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2.4rem',
+});
+
+export const fieldList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.2rem',
+});
+
+export const buttonContainer = style({
+  width: '100%',
+  marginTop: '1rem',
+});

--- a/src/pages/signup/ui/signup-step2/signup-step2.tsx
+++ b/src/pages/signup/ui/signup-step2/signup-step2.tsx
@@ -21,6 +21,10 @@ const ACADEMIC_STATUS_OPTIONS = ACADEMIC_STATUS_KEYS.map((key) => ({
   label: getAcademicStatusLabel(key),
 }));
 
+const isValidEntranceYear = (value: string): boolean => {
+  return /^\d{4}$/.test(value);
+};
+
 interface SignupStep2Props {
   values: SignupFormValues;
   onChange: (next: SignupFormValues) => void;
@@ -36,7 +40,7 @@ const isStep2Complete = (values: SignupFormValues): boolean => {
     values.mainRoleId != null &&
     values.universityId != null &&
     values.major.trim() !== '' &&
-    values.entranceYear.trim() !== '' &&
+    isValidEntranceYear(values.entranceYear.trim()) &&
     values.status != null
   );
 };

--- a/src/pages/signup/ui/signup-step2/signup-step2.tsx
+++ b/src/pages/signup/ui/signup-step2/signup-step2.tsx
@@ -1,0 +1,152 @@
+import type { SignupFormValues } from '@entities/signup/model/signup-form';
+import type { Option } from '@shared/types/common';
+import CtaButton from '@shared/ui/components/cta-button/cta-button';
+import {
+  Dropdown,
+  DropdownPanel,
+  DropdownTrigger,
+  FieldRoleContent,
+  UniversityContent,
+} from '@shared/ui/components/dropdown';
+import type { UniversityOption } from '@shared/ui/components/dropdown/dropdown-content/university-content';
+import TextField from '@shared/ui/components/field/textfield/textfield';
+import { getAcademicStatusLabel } from '@shared/utils/academic-status/academic-status';
+import { ACADEMIC_STATUS_KEYS } from '@shared/utils/academic-status/types';
+
+import SimpleSelect from '../simple-select/simple-select';
+import * as styles from './signup-step2.css';
+
+const ACADEMIC_STATUS_OPTIONS = ACADEMIC_STATUS_KEYS.map((key) => ({
+  value: key,
+  label: getAcademicStatusLabel(key),
+}));
+
+interface SignupStep2Props {
+  values: SignupFormValues;
+  onChange: (next: SignupFormValues) => void;
+  roleFields: Option[];
+  rolesByFieldOptions: Record<number, Option[]>;
+  universityOptions: UniversityOption[];
+  onSearchUniversity: (query: string) => void;
+  onNext: () => void;
+}
+
+const isStep2Complete = (values: SignupFormValues): boolean => {
+  return (
+    values.mainRoleId != null &&
+    values.universityId != null &&
+    values.major.trim() !== '' &&
+    values.entranceYear.trim() !== '' &&
+    values.status != null
+  );
+};
+
+const SignupStep2 = ({
+  values,
+  onChange,
+  roleFields,
+  rolesByFieldOptions,
+  universityOptions,
+  onSearchUniversity,
+  onNext,
+}: SignupStep2Props) => {
+  const isComplete = isStep2Complete(values);
+
+  const selectedRole =
+    values.mainRoleFieldId != null && values.mainRoleId != null
+      ? rolesByFieldOptions[values.mainRoleFieldId]?.find(
+          (r) => r.id === values.mainRoleId,
+        )
+      : null;
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.fieldList}>
+        <Dropdown>
+          <DropdownTrigger
+            placeholder='직군'
+            label={selectedRole != null ? selectedRole.name : undefined}
+          />
+          <DropdownPanel>
+            <FieldRoleContent
+              fields={roleFields}
+              rolesByFieldOptions={rolesByFieldOptions}
+              fieldId={values.mainRoleFieldId}
+              roleIds={values.mainRoleId != null ? [values.mainRoleId] : []}
+              onChange={(next) =>
+                onChange({
+                  ...values,
+                  mainRoleFieldId: next.fieldId,
+                  mainRoleId: next.roleIds[0] != null ? next.roleIds[0] : null,
+                })
+              }
+              singleSelect
+            />
+          </DropdownPanel>
+        </Dropdown>
+
+        <Dropdown>
+          <DropdownTrigger
+            placeholder='학교'
+            label={
+              values.universityName !== '' ? values.universityName : undefined
+            }
+          />
+          <DropdownPanel>
+            <UniversityContent
+              options={universityOptions}
+              value={values.universityId}
+              onChange={(option) =>
+                onChange({
+                  ...values,
+                  universityId: option.id,
+                  universityName: option.name,
+                })
+              }
+              onSearchChange={onSearchUniversity}
+            />
+          </DropdownPanel>
+        </Dropdown>
+
+        <TextField
+          value={values.major}
+          onChange={(e) => onChange({ ...values, major: e.target.value })}
+          placeholder='전공'
+        />
+
+        <TextField
+          value={values.entranceYear}
+          onChange={(e) =>
+            onChange({ ...values, entranceYear: e.target.value })
+          }
+          placeholder='입학연도 (예: 2022)'
+          type='number'
+        />
+
+        <SimpleSelect
+          options={ACADEMIC_STATUS_OPTIONS}
+          value={values.status}
+          placeholder='재휴학 / 졸업 여부'
+          onChange={(status) =>
+            onChange({
+              ...values,
+              status: status as SignupFormValues['status'],
+            })
+          }
+        />
+      </div>
+
+      <div className={styles.buttonContainer}>
+        <CtaButton
+          color={isComplete ? 'primary' : 'gray'}
+          disabled={!isComplete}
+          onClick={onNext}
+        >
+          다음
+        </CtaButton>
+      </div>
+    </div>
+  );
+};
+
+export default SignupStep2;

--- a/src/pages/signup/ui/signup-step3/signup-step3.css.ts
+++ b/src/pages/signup/ui/signup-step3/signup-step3.css.ts
@@ -1,0 +1,37 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '2.4rem',
+});
+
+export const grid = style({
+  display: 'grid',
+  gridTemplateColumns: '1fr 1fr',
+  gap: '2rem 3.2rem',
+});
+
+export const item = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.8rem',
+});
+
+export const itemTitle = style({
+  ...themeVars.font.body_14r,
+  color: themeVars.color.gray_800,
+  fontWeight: 600,
+});
+
+export const toggleGroup = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.6rem',
+});
+
+export const buttonContainer = style({
+  width: '100%',
+  marginTop: '1rem',
+});

--- a/src/pages/signup/ui/signup-step3/signup-step3.tsx
+++ b/src/pages/signup/ui/signup-step3/signup-step3.tsx
@@ -1,0 +1,72 @@
+import type { SignupFormValues } from '@entities/signup/model/signup-form';
+import CtaButton from '@shared/ui/components/cta-button/cta-button';
+import PersonalityToggle from '@shared/ui/components/personality-toggle/personality-toggle';
+import { getPersonalityLabelMeta } from '@shared/utils/personality/personality';
+import type { PersonalityValue } from '@shared/utils/personality/types';
+import { PERSONALITY_KEYS } from '@shared/utils/personality/types';
+
+import * as styles from './signup-step3.css';
+
+interface SignupStep3Props {
+  values: SignupFormValues;
+  onChange: (next: SignupFormValues) => void;
+  onNext: () => void;
+}
+
+const isStep3Complete = (values: SignupFormValues): boolean => {
+  return PERSONALITY_KEYS.every((key) => values.personality[key] != null);
+};
+
+const SignupStep3 = ({ values, onChange, onNext }: SignupStep3Props) => {
+  const isComplete = isStep3Complete(values);
+
+  const handleToggle = (
+    key: (typeof PERSONALITY_KEYS)[number],
+    value: PersonalityValue,
+  ) => {
+    onChange({
+      ...values,
+      personality: { ...values.personality, [key]: value },
+    });
+  };
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.grid}>
+        {PERSONALITY_KEYS.map((key) => {
+          const meta = getPersonalityLabelMeta(key);
+          const selected = values.personality[key];
+
+          return (
+            <div key={key} className={styles.item}>
+              <p className={styles.itemTitle}>{meta.title}</p>
+              <div className={styles.toggleGroup}>
+                {([0, 1] as PersonalityValue[]).map((value) => (
+                  <PersonalityToggle
+                    key={value}
+                    selected={selected === value}
+                    onSelect={() => handleToggle(key, value)}
+                  >
+                    {meta.labels[value]}
+                  </PersonalityToggle>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      <div className={styles.buttonContainer}>
+        <CtaButton
+          color={isComplete ? 'primary' : 'gray'}
+          disabled={!isComplete}
+          onClick={onNext}
+        >
+          다음
+        </CtaButton>
+      </div>
+    </div>
+  );
+};
+
+export default SignupStep3;

--- a/src/pages/signup/ui/simple-select/simple-select.css.ts
+++ b/src/pages/signup/ui/simple-select/simple-select.css.ts
@@ -1,0 +1,45 @@
+import { themeVars } from '@shared/styles';
+import { style } from '@vanilla-extract/css';
+
+export const container = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.8rem',
+});
+
+export const placeholder = style({
+  ...themeVars.font.body_14r,
+  color: themeVars.color.gray_400,
+});
+
+export const optionGroup = style({
+  display: 'flex',
+  gap: '0.8rem',
+  flexWrap: 'wrap',
+});
+
+const optionBase = style({
+  padding: '0.8rem 1.6rem',
+  border: `1px solid ${themeVars.color.gray_200}`,
+  borderRadius: '20px',
+  ...themeVars.font.body_14r,
+  cursor: 'pointer',
+});
+
+export const option = style([
+  optionBase,
+  {
+    backgroundColor: themeVars.color.gray_000,
+    color: themeVars.color.gray_500,
+  },
+]);
+
+export const optionSelected = style([
+  optionBase,
+  {
+    backgroundColor: themeVars.color.primary_light2,
+    color: themeVars.color.primary,
+    borderColor: themeVars.color.primary,
+    ...themeVars.font.body_14m,
+  },
+]);

--- a/src/pages/signup/ui/simple-select/simple-select.tsx
+++ b/src/pages/signup/ui/simple-select/simple-select.tsx
@@ -1,0 +1,42 @@
+import * as styles from './simple-select.css';
+
+interface SimpleSelectOption {
+  value: string;
+  label: string;
+}
+
+interface SimpleSelectProps {
+  options: SimpleSelectOption[];
+  value: string | null;
+  placeholder: string;
+  onChange: (value: string) => void;
+}
+
+const SimpleSelect = ({
+  options,
+  value,
+  placeholder,
+  onChange,
+}: SimpleSelectProps) => {
+  return (
+    <div className={styles.container}>
+      {value == null && <p className={styles.placeholder}>{placeholder}</p>}
+      <div className={styles.optionGroup}>
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type='button'
+            className={
+              value === option.value ? styles.optionSelected : styles.option
+            }
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default SimpleSelect;

--- a/src/shared/assets/icons/icn-progress-completed.svg
+++ b/src/shared/assets/icons/icn-progress-completed.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M9.54961 18.0001L3.84961 12.3001L5.27461 10.8751L9.54961 15.1501L18.7246 5.9751L20.1496 7.4001L9.54961 18.0001Z" fill="white"/>
+</svg>

--- a/src/shared/assets/icons/index.ts
+++ b/src/shared/assets/icons/index.ts
@@ -4,6 +4,7 @@ export { default as BackIcon } from './icn-back.svg?react';
 export { default as CheckIcon } from './icn-check.svg?react';
 export { default as DateIcon } from './icn-date.svg?react';
 export { default as ProfileIcon } from './icn-profile.svg?react';
+export { default as ProgressCompletedIcon } from './icn-progress-completed.svg?react';
 export { default as ResetIcon } from './icn-reset.svg?react';
 export { default as StepperLeftIcon } from './icn-stepperLeft.svg?react';
 export { default as StepperRightIcon } from './icn-stepperRight.svg?react';

--- a/src/shared/ui/components/dropdown/index.ts
+++ b/src/shared/ui/components/dropdown/index.ts
@@ -3,6 +3,7 @@ export { default as DomainContent } from './dropdown-content/domain-content';
 export { default as FieldRoleContent } from './dropdown-content/field-role-content';
 export { default as FieldSkillContent } from './dropdown-content/field-skill-content';
 export { default as PersonalityContent } from './dropdown-content/personality-content';
+export { default as UniversityContent } from './dropdown-content/university-content';
 export { useDropdownContext } from './dropdown-context';
 export { default as DropdownPanel } from './dropdown-panel';
 export { default as DropdownTrigger } from './dropdown-trigger';

--- a/src/shared/utils/academic-status/types.ts
+++ b/src/shared/utils/academic-status/types.ts
@@ -14,5 +14,5 @@ const ACADEMIC_STATUS_KEY_SET: ReadonlySet<string> = new Set(
 export const isAcademicStatusKey = (
   value: string,
 ): value is AcademicStatusKey => {
-  return ACADEMIC_STATUS_KEY_SET.has(value);
+  return (ACADEMIC_STATUS_KEY_SET as ReadonlySet<string>).has(value);
 };


### PR DESCRIPTION
## 📌 Summary

> #91 
회원가입 페이지 뷰 작업

## 📚 Tasks

- API 응답 타입 정의
- 온보딩 step 1, 2, 3 컴포넌트 작성
- `isAcademicStatusKey` 타입 오류 수정
- 회원가입 페이지 전체 뷰 작업

## 🔍 Describe

### 스텝 상태 관리

`SignupPage`에서 `step: 1 | 2 | 3 | 'complete'`로 현재 스텝을 관리합니다. `SignupFormValues`는 전체 스텝에 걸쳐 하나의 상태로 유지되고, 각 스텝 컴포넌트는 `values`와 `onChange`를 props로 받습니다.
`CtaButton`에  `isStepNComplete()` 함수로 완성 여부를 판단해 `color`와 `disabled`를 함께 넘기고, 모든 필드가 채워졌을 때만 `primary` 색상으로 활성화되도록 했습니다.

# personality 타입

`SignupFormValues`의 `personality`는 `Partial<Personality>`로 선언해 입력 중간 상태(아직 선택 안 한 키)를 표현해요. `isStep3Complete()`에서 `PERSONALITY_KEYS.every(key => values.personality[key] != null)`로 검증하고, 제출 시 `as Personality`로 캐스팅해요. `SignupRequest`의 `personality`는 `Personality`(non-partial)로 선언해 API 레벨에서는 완성된 값만 허용합니다.

### 닉네임 중복확인

중복확인 후 닉네임을 수정하면 `isUsernameChecked`를 `false`로 리셋해요. 재확인을 강제해 중복된 닉네임으로 진행하는 상황을 방지합니다. API 연결 시 `GET /api/auth/username?q=:username`을 호출하면 돼요.

### 대학교 검색

`onSearchUniversity`에서 현재는 mock 데이터를 `string.includes()`로 필터링해요. API 연결 시 `GET /api/university?q=:query`로 교체하면 됩니다.

### SimpleSelect 컴포넌트

성별(남성/여성)과 재휴학 여부처럼 선택지가 적은 경우를 위해 pill 형태의 단순 선택 컴포넌트를 새로 만들었어요. 기존 `Dropdown` 구조를 쓰지 않고 옵션을 바로 노출하는 방식으로, 페이지 스타일에 맞게 mint 계열 선택 스타일을 적용했습니다.

### isAcademicStatusKey 오류 수정

`ReadonlySet<string>`으로 선언된 `ACADEMIC_STATUS_KEY_SET`을 `ReadonlySet<AcademicStatusKey>`로 변경하고, `.has()` 호출 시 `as ReadonlySet<string>`으로 캐스팅해 타입 순환 참조를 끊었습니다.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 3단계 회원가입 페이지 추가 (기본 정보, 교육 정보, 성향 선택)
  * 진행 상황 표시 인디케이터 추가
  * 아이디 중복확인 버튼 추가
  * 대학교 검색 및 선택 기능 추가
  * 직무/분야 선택 드롭다운 및 간단 선택(Pill) UI 추가
  * 성향 선택 토글 UI 추가
  * 회원가입 완료 화면 및 시작 버튼 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2025-TEAM-LGTM/UniON-client/pull/101)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->