### PR TITLE
[Feat] 공고 조회 페이지 API 연결

### DIFF
--- a/src/entities/domain/api/domain-api.ts
+++ b/src/entities/domain/api/domain-api.ts
@@ -1,0 +1,6 @@
+import type { DomainResponse } from '@entities/domain/types';
+import { get } from '@shared/api/http';
+
+export const getDomains = (): Promise<DomainResponse[]> => {
+  return get<DomainResponse[]>('/api/dropdown/domains');
+};

--- a/src/entities/domain/api/use-get-domain.ts
+++ b/src/entities/domain/api/use-get-domain.ts
@@ -1,0 +1,12 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getDomains } from './domain-api';
+
+export const useGetDomains = () => {
+  return useQuery({
+    queryKey: queryKeys.domain.all,
+    queryFn: getDomains,
+    staleTime: Infinity,
+  });
+};

--- a/src/entities/field-role/api/field-role-api.ts
+++ b/src/entities/field-role/api/field-role-api.ts
@@ -1,0 +1,15 @@
+import type { GetFieldRoleResponse } from '@entities/field-role/types';
+import { get } from '@shared/api/http';
+
+export interface GetFieldRoleParams {
+  fieldId?: number | null;
+}
+
+export const getFieldRole = (
+  params?: GetFieldRoleParams,
+): Promise<GetFieldRoleResponse> => {
+  return get<GetFieldRoleResponse, Record<string, unknown>>(
+    '/api/dropdown/roles',
+    params?.fieldId != null ? { fieldId: params.fieldId } : undefined,
+  );
+};

--- a/src/entities/field-role/api/use-field-role.ts
+++ b/src/entities/field-role/api/use-field-role.ts
@@ -1,0 +1,11 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getFieldRole, type GetFieldRoleParams } from './field-role-api';
+
+export const useGetFieldRole = (params?: GetFieldRoleParams) => {
+  return useQuery({
+    queryKey: queryKeys.fieldRole.list(params?.fieldId),
+    queryFn: () => getFieldRole(params),
+  });
+};

--- a/src/entities/posts/api/apply-api.ts
+++ b/src/entities/posts/api/apply-api.ts
@@ -1,0 +1,16 @@
+import { del, post } from '@shared/api/http';
+
+export interface ApplyResponse {
+  applyId: number;
+  postId: number;
+  applicantUserId: number;
+  applyDate: string;
+}
+
+export const applyPost = (postId: number): Promise<ApplyResponse> => {
+  return post<ApplyResponse>(`/api/posts/${postId}/applications`);
+};
+
+export const cancelApply = (postId: number): Promise<ApplyResponse> => {
+  return del<ApplyResponse>(`/api/posts/${postId}/applications/me`);
+};

--- a/src/entities/posts/api/posts-api.ts
+++ b/src/entities/posts/api/posts-api.ts
@@ -1,0 +1,19 @@
+import { get } from '@shared/api/http';
+
+import type { PostsDataResponse } from './types';
+
+export interface GetPostsParams {
+  d?: number[];
+  f?: number | null;
+  r?: number[];
+}
+
+export const getPosts = (
+  params: GetPostsParams,
+): Promise<PostsDataResponse> => {
+  return get<PostsDataResponse, Record<string, unknown>>('/api/posts', {
+    ...(params.d && params.d.length > 0 && { d: params.d }),
+    ...(params.f != null && { f: params.f }),
+    ...(params.r && params.r.length > 0 && { r: params.r }),
+  });
+};

--- a/src/entities/posts/api/use-get-posts.ts
+++ b/src/entities/posts/api/use-get-posts.ts
@@ -1,0 +1,11 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getPosts, type GetPostsParams } from './posts-api';
+
+export const useGetPosts = (params: GetPostsParams) => {
+  return useQuery({
+    queryKey: queryKeys.posts.list(params),
+    queryFn: () => getPosts(params),
+  });
+};

--- a/src/entities/posts/api/use-toggle-apply.ts
+++ b/src/entities/posts/api/use-toggle-apply.ts
@@ -1,0 +1,21 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { applyPost, cancelApply } from './apply-api';
+
+interface ToggleApplyParams {
+  postId: number;
+  wasApplied: boolean;
+}
+
+export const useToggleApply = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ postId, wasApplied }: ToggleApplyParams) =>
+      wasApplied ? cancelApply(postId) : applyPost(postId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
+    },
+  });
+};

--- a/src/pages/posts/posts.tsx
+++ b/src/pages/posts/posts.tsx
@@ -1,4 +1,7 @@
-import { filterPosts } from '@features/posts/model/filter-posts';
+import { useGetDomains } from '@entities/domain/api/use-get-domain';
+import { useGetFieldRole } from '@entities/field-role/api/use-field-role';
+import { useGetPosts } from '@entities/posts/api/use-get-posts';
+import { useToggleApply } from '@entities/posts/api/use-toggle-apply';
 import { EMPTY_FILTERS } from '@features/posts/model/filters-state';
 import { ResetIcon } from '@shared/assets/icons';
 import { parseFieldRoleResponse } from '@shared/lib/filter/parse-field-role-response';
@@ -6,12 +9,9 @@ import Banner from '@shared/ui/components/banner/banner';
 import Button from '@shared/ui/components/button/button';
 import { useToast } from '@shared/ui/components/toast/toast-context';
 import PostDropdownGroup from '@widgets/post-dropdown-group/post-dropdown-group';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { MOCK_DOMAIN_OPTIONS } from './mock/mock-domain-options';
-import { MOCK_FIELD_ROLE_RESPONSE } from './mock/mock-field-role-response';
-import { MOCK_POST_RESPONSE } from './mock/mock-posts-response';
 import * as styles from './post.css';
 import PostCardGroup from './widgets/post-card-group/post-card-group';
 
@@ -21,47 +21,47 @@ const PostsPage = () => {
   const onClick = () => navigate('/posts/new');
 
   const pendingRef = useRef<Set<number>>(new Set());
-
-  const posts = useMemo(() => MOCK_POST_RESPONSE.data.posts, []);
-
   const [filters, setFilters] = useState(EMPTY_FILTERS);
+
+  const { data: fieldRoleData } = useGetFieldRole();
+  const { data: domainData } = useGetDomains();
+  const {
+    data: postsData,
+    isLoading,
+    isError,
+  } = useGetPosts({
+    d: filters.domainIds,
+    f: filters.fieldId,
+    r: filters.roleIds,
+  });
+  const { mutateAsync: toggleApply } = useToggleApply();
+
   const { fields, rolesByFieldOptions } = useMemo(
-    () => parseFieldRoleResponse(MOCK_FIELD_ROLE_RESPONSE.data),
-    [],
+    () => parseFieldRoleResponse(fieldRoleData ?? []),
+    [fieldRoleData],
   );
 
-  const filteredPosts = useMemo(
-    () => filterPosts(posts, filters),
-    [posts, filters],
-  );
+  const domains = domainData ?? [];
+  const posts = useMemo(() => postsData?.posts ?? [], [postsData]);
 
-  const [appliedIds, setAppliedIds] = useState<Set<number>>(() => {
+  const [appliedIds, setAppliedIds] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
     const set = new Set<number>();
-
     posts.forEach((p) => {
       if (p.applied) set.add(p.postId);
     });
-
-    return set;
-  });
-
-  const requestToggleApply = async (postId: number, nextApplied: boolean) => {
-    // TODO: API 연결 후 수정
-    void postId;
-    void nextApplied;
-    if (Math.random() < 0.2) throw new Error('server error');
-  };
+    setAppliedIds(set);
+  }, [posts]);
 
   const handleToggleApply = async (postId: number) => {
-    // TODO: API 연결
     if (pendingRef.current.has(postId)) return;
 
     const wasApplied = appliedIds.has(postId);
-    const nextApplied = !wasApplied;
 
     setAppliedIds((prev) => {
       const next = new Set(prev);
-      if (next.has(postId)) next.delete(postId);
+      if (wasApplied) next.delete(postId);
       else next.add(postId);
       return next;
     });
@@ -69,12 +69,8 @@ const PostsPage = () => {
     pendingRef.current.add(postId);
 
     try {
-      // TODO: 수정
-      await requestToggleApply(postId, nextApplied);
-
-      toast.success(
-        nextApplied ? '지원이 완료되었어요' : '지원이 취소되었어요',
-      );
+      await toggleApply({ postId, wasApplied });
+      toast.success(wasApplied ? '지원이 취소되었어요' : '지원이 완료되었어요');
     } catch {
       setAppliedIds((prev) => {
         const next = new Set(prev);
@@ -82,7 +78,6 @@ const PostsPage = () => {
         else next.delete(postId);
         return next;
       });
-
       toast.error('서버 오류가 발생했어요. 잠시 후 다시 시도해 주세요.');
     } finally {
       pendingRef.current.delete(postId);
@@ -91,6 +86,7 @@ const PostsPage = () => {
 
   const handleRefresh = () => {
     setFilters(EMPTY_FILTERS);
+    console.log(import.meta.env.VITE_API_BASE_URL);
   };
 
   return (
@@ -111,13 +107,12 @@ const PostsPage = () => {
 
         <section className={styles.filterContainer}>
           <PostDropdownGroup
-            domains={MOCK_DOMAIN_OPTIONS}
+            domains={domains}
             fields={fields}
             rolesByFieldOptions={rolesByFieldOptions}
             value={filters}
             onChange={setFilters}
           />
-
           <button
             type='button'
             className={styles.refreshButton}
@@ -128,13 +123,29 @@ const PostsPage = () => {
           </button>
         </section>
 
-        {filteredPosts.length === 0 ? (
+        {isLoading && (
+          <section className={styles.emptyContainer}>
+            <p className={styles.emptyText}>불러오는 중...</p>
+          </section>
+        )}
+
+        {isError && (
+          <section className={styles.emptyContainer}>
+            <p className={styles.emptyText}>
+              오류가 발생했어요. 다시 시도해 주세요.
+            </p>
+          </section>
+        )}
+
+        {!isLoading && !isError && posts.length === 0 && (
           <section className={styles.emptyContainer}>
             <p className={styles.emptyText}>검색 결과가 없어요!</p>
           </section>
-        ) : (
+        )}
+
+        {!isLoading && !isError && posts.length > 0 && (
           <PostCardGroup
-            posts={filteredPosts}
+            posts={posts}
             appliedIds={appliedIds}
             onToggleApply={handleToggleApply}
           />

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -1,7 +1,8 @@
+import { ENV } from '@shared/constants/env';
 import axios from 'axios';
 
 export const instance = axios.create({
-  baseURL: '', // TODO: baseURL 연결
+  baseURL: ENV.API_BASE_URL,
   timeout: 15000,
 });
 

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -5,4 +5,12 @@ export const queryKeys = {
     all: ['posts'] as const,
     list: (params: GetPostsParams) => ['posts', 'list', params] as const,
   },
+  fieldRole: {
+    all: ['fieldRole'] as const,
+    list: (fieldId?: number | null) =>
+      ['fieldRole', 'list', fieldId ?? null] as const,
+  },
+  domain: {
+    all: ['domain'] as const,
+  },
 } as const;

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -1,0 +1,8 @@
+import type { GetPostsParams } from '@entities/posts/api/posts-api';
+
+export const queryKeys = {
+  posts: {
+    all: ['posts'] as const,
+    list: (params: GetPostsParams) => ['posts', 'list', params] as const,
+  },
+} as const;

--- a/src/widgets/post-card/post-card.tsx
+++ b/src/widgets/post-card/post-card.tsx
@@ -45,7 +45,7 @@ const PostCard = ({
         aria-label={`${title} 상세 페이지로 이동`}
         className={styles.overlay}
       />
-      <span className={styles.dday}>D-{dday}</span>
+      <span className={styles.dday}>D{dday}</span>
 
       <div className={styles.textContainer}>
         <p className={styles.title}>{title}</p>


### PR DESCRIPTION
## 📌 Summary

> #102 
공고 조회 페이지 API 연결

## 📚 Tasks

- `instance.ts` 환경변수 연결
- 공고 목록 GET API 연결
- 지원/지원 취소 API 연결
- 목데이터, 클라이언트 로컬 필터링 로직 삭제 (서버 필터링으로 대체)
- 쿼리키 중앙 관리 파일 작성 (@shared/constants/query-keys.ts)

## 🔍 Describe

환경변수를 연결하고, 공고 목록 조회 페이지의 API들을 연동했어요. 

appliedIds는 서버 응답의 applied 필드를 source of truth로 삼습니다. 네트워크 지연 동안 UX를 위해 낙관적 업데이트를 적용하고, 성공 시 invalidateQueries로 서버 상태를 다시 받아와 useEffect로 동기화합니다. 실패 시에는 이전 상태로 롤백합니다.

도메인 목록은 자주 바뀌지 않는 정적 데이터에 가까워 staleTime: Infinity로 설정해 불필요한 재요청을 방지했습니다.


## 👀 To Reviewer
추후에 필요에 따라 도메인 한글 파싱 로직을 추가해야 할 것 같아요!

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 게시물 지원/취소 신청 기능 추가
  * 실시간 서버 데이터 동기화 적용

* **개선**
  * D-day 라벨 형식 개선
  * 로딩 및 오류 상태 UI 추가

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2025-TEAM-LGTM/UniON-client/pull/104)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->