### PR TITLE
[Feat] 회원가입 API 연결

### DIFF
--- a/src/entities/signup/api/signup-api.ts
+++ b/src/entities/signup/api/signup-api.ts
@@ -1,0 +1,17 @@
+import { get, post } from '@shared/api/http';
+
+import type {
+  SignupRequest,
+  SignupResponseData,
+  UsernameCheckResponseData,
+} from './types';
+
+export const checkUsername = (
+  username: string,
+): Promise<UsernameCheckResponseData> => {
+  return get<UsernameCheckResponseData>('/api/auth/username', { q: username });
+};
+
+export const signup = (body: SignupRequest): Promise<SignupResponseData> => {
+  return post<SignupResponseData, SignupRequest>('/api/auth/signup', body);
+};

--- a/src/entities/signup/api/use-check-username.ts
+++ b/src/entities/signup/api/use-check-username.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { checkUsername } from './signup-api';
+
+export const useCheckUsername = () => {
+  return useMutation({
+    mutationFn: (username: string) => checkUsername(username),
+  });
+};

--- a/src/entities/signup/api/use-signup.ts
+++ b/src/entities/signup/api/use-signup.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { signup } from './signup-api';
+import type { SignupRequest } from './types';
+
+export const useSignup = () => {
+  return useMutation({
+    mutationFn: (body: SignupRequest) => signup(body),
+  });
+};

--- a/src/entities/signup/model/adapters.ts
+++ b/src/entities/signup/model/adapters.ts
@@ -1,0 +1,31 @@
+import type { AcademicStatusKey } from '@shared/utils/academic-status/types';
+import type { Personality } from '@shared/utils/personality/types';
+
+import type { SignupRequest } from '../api/types';
+import type { SignupFormValues } from './signup-form';
+
+export const toSignupRequest = (values: SignupFormValues): SignupRequest => {
+  if (
+    values.mainRoleId == null ||
+    values.universityId == null ||
+    values.gender == null ||
+    values.status == null
+  ) {
+    throw new Error('필수 값이 누락되었습니다.');
+  }
+
+  return {
+    loginId: values.loginId.trim(),
+    password: values.password.trim(),
+    email: values.email.trim(),
+    username: values.username.trim(),
+    birthYear: Number(values.birthYear),
+    gender: values.gender as SignupRequest['gender'],
+    mainRoleId: values.mainRoleId,
+    universityId: values.universityId,
+    major: values.major.trim(),
+    entranceYear: Number(values.entranceYear),
+    status: values.status as AcademicStatusKey,
+    personality: values.personality as Personality,
+  };
+};

--- a/src/entities/university/api/university-api.ts
+++ b/src/entities/university/api/university-api.ts
@@ -1,0 +1,6 @@
+import { get } from '@shared/api/http';
+import type { Option } from '@shared/types/common';
+
+export const getUniversities = (query?: string): Promise<Option[]> => {
+  return get<Option[]>('/api/university', query ? { q: query } : undefined);
+};

--- a/src/entities/university/api/university-api.ts
+++ b/src/entities/university/api/university-api.ts
@@ -2,5 +2,8 @@ import { get } from '@shared/api/http';
 import type { Option } from '@shared/types/common';
 
 export const getUniversities = (query?: string): Promise<Option[]> => {
-  return get<Option[]>('/api/university', query ? { q: query } : undefined);
+  return get<Option[]>(
+    '/api/dropdown/universities',
+    query ? { q: query } : undefined,
+  );
 };

--- a/src/entities/university/api/use-get-universities.ts
+++ b/src/entities/university/api/use-get-universities.ts
@@ -1,0 +1,12 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useQuery } from '@tanstack/react-query';
+
+import { getUniversities } from './university-api';
+
+export const useGetUniversities = (query: string) => {
+  return useQuery({
+    queryKey: queryKeys.university.list(query),
+    queryFn: () => getUniversities(query),
+    staleTime: 30_000,
+  });
+};

--- a/src/pages/signup/signup.tsx
+++ b/src/pages/signup/signup.tsx
@@ -1,15 +1,15 @@
-// pages/signup/signup-page.tsx
-
+import { useGetFieldRole } from '@entities/field-role/api/use-field-role';
+import { useCheckUsername } from '@entities/signup/api/use-check-username';
+import { useSignup } from '@entities/signup/api/use-signup';
+import { toSignupRequest } from '@entities/signup/model/adapters';
 import { createEmptySignupFormValues } from '@entities/signup/model/signup-form';
+import { useGetUniversities } from '@entities/university/api/use-get-universities';
 import { ROUTE_PATH } from '@shared/constants/path';
-import { useState } from 'react';
+import { parseFieldRoleResponse } from '@shared/lib/filter/parse-field-role-response';
+import { useToast } from '@shared/ui/components/toast/toast-context';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import {
-  SIGNUP_ROLE_FIELDS,
-  SIGNUP_ROLES_BY_FIELD,
-} from './mock/mock-signup-roles';
-import { MOCK_UNIVERSITIES } from './mock/mock-signup-universities';
 import * as styles from './signup.css';
 import SignupComplete from './ui/signup-complete/signup-complete';
 import SignupProgress from './ui/signup-progress/signup-progress';
@@ -21,27 +21,53 @@ type SignupStep = 1 | 2 | 3 | 'complete';
 
 const SignupPage = () => {
   const navigate = useNavigate();
+  const toast = useToast();
+
   const [step, setStep] = useState<SignupStep>(1);
   const [formValues, setFormValues] = useState(createEmptySignupFormValues());
   const [isUsernameChecked, setIsUsernameChecked] = useState(false);
-  const [universityOptions, setUniversityOptions] = useState(MOCK_UNIVERSITIES);
+  const [universityQuery, setUniversityQuery] = useState('');
 
-  const handleCheckUsername = () => {
-    // TODO: GET /api/auth/username?q=:username 연결
-    console.log('중복확인:', formValues.username);
-    setIsUsernameChecked(true);
+  const { data: fieldRoleData } = useGetFieldRole();
+  const { data: universityData } = useGetUniversities(universityQuery);
+  const { mutateAsync: checkUsername, isPending: isCheckingUsername } =
+    useCheckUsername();
+  const { mutateAsync: signupMutate, isPending: isSigningUp } = useSignup();
+
+  const { fields: roleFields, rolesByFieldOptions } = useMemo(
+    () => parseFieldRoleResponse(fieldRoleData ?? []),
+    [fieldRoleData],
+  );
+
+  const universityOptions = universityData ?? [];
+
+  const handleCheckUsername = async () => {
+    try {
+      const { available } = await checkUsername(formValues.username);
+      if (available) {
+        toast.success('사용 가능한 닉네임이에요.');
+        setIsUsernameChecked(true);
+      } else {
+        toast.error('이미 사용 중인 닉네임이에요.');
+        setIsUsernameChecked(false);
+      }
+    } catch {
+      toast.error('닉네임 확인 중 오류가 발생했어요. 다시 시도해 주세요.');
+    }
   };
 
   const handleSearchUniversity = (query: string) => {
-    // TODO: GET /api/university?q=:query 연결
-    const filtered = MOCK_UNIVERSITIES.filter((u) => u.name.includes(query));
-    setUniversityOptions(filtered);
+    setUniversityQuery(query);
   };
 
-  const handleSubmit = () => {
-    // TODO: POST /api/auth/signup 연결
-    console.log(formValues);
-    setStep('complete');
+  const handleSubmit = async () => {
+    try {
+      const body = toSignupRequest(formValues);
+      await signupMutate(body);
+      setStep('complete');
+    } catch {
+      toast.error('회원가입 중 오류가 발생했어요. 다시 시도해 주세요.');
+    }
   };
 
   const handleStart = () => {
@@ -80,6 +106,7 @@ const SignupPage = () => {
           <SignupStep1
             values={formValues}
             onChange={handleUsernameChange}
+            isCheckingUsername={isCheckingUsername}
             isUsernameChecked={isUsernameChecked}
             onCheckUsername={handleCheckUsername}
             onNext={() => setStep(2)}
@@ -89,8 +116,8 @@ const SignupPage = () => {
           <SignupStep2
             values={formValues}
             onChange={setFormValues}
-            roleFields={SIGNUP_ROLE_FIELDS}
-            rolesByFieldOptions={SIGNUP_ROLES_BY_FIELD}
+            roleFields={roleFields}
+            rolesByFieldOptions={rolesByFieldOptions}
             universityOptions={universityOptions}
             onSearchUniversity={handleSearchUniversity}
             onNext={() => setStep(3)}
@@ -98,6 +125,7 @@ const SignupPage = () => {
         )}
         {step === 3 && (
           <SignupStep3
+            isSubmitting={isSigningUp}
             values={formValues}
             onChange={setFormValues}
             onNext={handleSubmit}

--- a/src/pages/signup/ui/signup-step1/signup-step1.tsx
+++ b/src/pages/signup/ui/signup-step1/signup-step1.tsx
@@ -14,6 +14,7 @@ const GENDER_OPTIONS = [
 interface SignupStep1Props {
   values: SignupFormValues;
   onChange: (next: SignupFormValues) => void;
+  isCheckingUsername: boolean;
   isUsernameChecked: boolean;
   onCheckUsername: () => void;
   onNext: () => void;
@@ -38,6 +39,7 @@ const SignupStep1 = ({
   values,
   onChange,
   isUsernameChecked,
+  isCheckingUsername,
   onCheckUsername,
   onNext,
 }: SignupStep1Props) => {
@@ -67,7 +69,7 @@ const SignupStep1 = ({
           />
           <button
             className={styles.checkButton}
-            disabled={values.username.trim() === ''}
+            disabled={values.username.trim() === '' || isCheckingUsername}
             onClick={onCheckUsername}
           >
             중복확인

--- a/src/pages/signup/ui/signup-step3/signup-step3.tsx
+++ b/src/pages/signup/ui/signup-step3/signup-step3.tsx
@@ -9,6 +9,7 @@ import * as styles from './signup-step3.css';
 
 interface SignupStep3Props {
   values: SignupFormValues;
+  isSubmitting: boolean;
   onChange: (next: SignupFormValues) => void;
   onNext: () => void;
 }
@@ -17,7 +18,12 @@ const isStep3Complete = (values: SignupFormValues): boolean => {
   return PERSONALITY_KEYS.every((key) => values.personality[key] != null);
 };
 
-const SignupStep3 = ({ values, onChange, onNext }: SignupStep3Props) => {
+const SignupStep3 = ({
+  values,
+  onChange,
+  onNext,
+  isSubmitting,
+}: SignupStep3Props) => {
   const isComplete = isStep3Complete(values);
 
   const handleToggle = (
@@ -59,7 +65,7 @@ const SignupStep3 = ({ values, onChange, onNext }: SignupStep3Props) => {
       <div className={styles.buttonContainer}>
         <CtaButton
           color={isComplete ? 'primary' : 'gray'}
-          disabled={!isComplete}
+          disabled={!isComplete || isSubmitting}
           onClick={onNext}
         >
           다음

--- a/src/shared/constants/query-keys.ts
+++ b/src/shared/constants/query-keys.ts
@@ -52,4 +52,8 @@ export const queryKeys = {
   personality: {
     all: ['personality'] as const,
   },
+  university: {
+    all: ['university'] as const,
+    list: (query: string) => ['university', 'list', query] as const,
+  },
 } as const;


### PR DESCRIPTION
## 📌 Summary

> #121 
회원가입 API 연결

## 📚 Tasks

- 닉네임 중복검사 API 연결
- 회원가입 API 연결
- role, university dropdown 401 문제 해결
- university 드롭다운 API 연결
- adapter 추가

## 🔍 Describe

### 닉네임 중복검사
버튼 클릭 시에만 요청해야 하므로 useQuery 대신 useMutation으로 구현했어요. 사용 가능 여부는 응답의 available 여부로 판단하며, 불가능해도 200이 내려오는 API 명세에 맞게 처리했습니다.
닉네임이 변경되면 isUsernameChecked를 false로 초기화해 재확인을 강제합니다.

### 대학교 드롭다운
검색어가 바뀔 때마다 GET API를 재요청합니다. 검색어가 없으면 전체 목록을 가져옵니다.

### 중복 제출 방지
isCheckingUsername, isSigningUp 상태를 각 스텝 컴포넌트에 전달해 요청 중 버튼을 비활성화합니다.

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->
