### PR TITLE
[Feat] 내 포트폴리오 수정하기 API 연동

### DIFF
--- a/src/entities/portfolio-form/api/portfolio-form-api.ts
+++ b/src/entities/portfolio-form/api/portfolio-form-api.ts
@@ -1,8 +1,10 @@
-import { post } from '@shared/api/http';
+import { patch, post } from '@shared/api/http';
 
 import type {
   CreatePortfolioRequest,
   CreatePortfolioResponseData,
+  PortfolioDetailResponse,
+  UpdatePortfolioRequest,
 } from './types';
 
 export const createPortfolio = (
@@ -10,6 +12,16 @@ export const createPortfolio = (
 ): Promise<CreatePortfolioResponseData> => {
   return post<CreatePortfolioResponseData, CreatePortfolioRequest>(
     '/api/me/portfolio',
+    body,
+  );
+};
+
+export const updatePortfolio = (
+  portfolioId: string,
+  body: UpdatePortfolioRequest,
+): Promise<PortfolioDetailResponse> => {
+  return patch<PortfolioDetailResponse, UpdatePortfolioRequest>(
+    `/api/me/portfolio/${portfolioId}`,
     body,
   );
 };

--- a/src/entities/portfolio-form/api/types.ts
+++ b/src/entities/portfolio-form/api/types.ts
@@ -44,3 +44,18 @@ export interface CreatePortfolioResponseData {
 
 export type CreatePortfolioResponse =
   SuccessResponse<CreatePortfolioResponseData>;
+
+export interface UpdatePortfolioRequest {
+  title?: string;
+  summary?: string;
+  domainId?: number;
+  roleId?: number;
+  headcount?: number;
+  externUrl?: string;
+  Stext?: string;
+  Ttext?: string;
+  Atext?: string;
+  Rtext?: string;
+  imageKey?: string | null;
+  imageSize?: number | null;
+}

--- a/src/entities/portfolio-form/model/use-update-portfolio.ts
+++ b/src/entities/portfolio-form/model/use-update-portfolio.ts
@@ -1,0 +1,39 @@
+import { uploadImage } from '@shared/api/image-upload';
+import { queryKeys } from '@shared/constants/query-keys';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { updatePortfolio } from '../api/portfolio-form-api';
+import type { PortfolioFormValues } from '../model/portfolio-form';
+
+export const useUpdatePortfolio = (portfolioId: string) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (values: PortfolioFormValues) => {
+      const imageMeta =
+        values.image.file != null
+          ? await uploadImage(values.image.file)
+          : { imageKey: null, imageSize: null };
+
+      return updatePortfolio(portfolioId, {
+        title: values.title.trim(),
+        summary: values.summary.trim(),
+        domainId: values.domainId ?? undefined,
+        roleId: values.roleId ?? undefined,
+        headcount: values.headcount,
+        externUrl: values.externUrl.trim(),
+        Stext: values.Stext.trim(),
+        Ttext: values.Ttext.trim(),
+        Atext: values.Atext.trim(),
+        Rtext: values.Rtext.trim(),
+        imageKey: imageMeta.imageKey,
+        imageSize: imageMeta.imageSize,
+      });
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.me.portfolioDetail(portfolioId),
+      });
+    },
+  });
+};

--- a/src/entities/portfolio-form/model/use-update-portfolio.ts
+++ b/src/entities/portfolio-form/model/use-update-portfolio.ts
@@ -13,7 +13,7 @@ export const useUpdatePortfolio = (portfolioId: string) => {
       const imageMeta =
         values.image.file != null
           ? await uploadImage(values.image.file)
-          : { imageKey: null, imageSize: null };
+          : { imageKey: undefined, imageSize: undefined };
 
       return updatePortfolio(portfolioId, {
         title: values.title.trim(),

--- a/src/pages/edit-portfolio/edit-portfolio.tsx
+++ b/src/pages/edit-portfolio/edit-portfolio.tsx
@@ -1,21 +1,81 @@
 import { useGetDomains } from '@entities/domain/api/use-get-domain';
 import { useGetFieldRole } from '@entities/field-role/api/use-field-role';
+import { useGetMyPortfolioDetail } from '@entities/portfolio-details/api/use-get-portfolio-details';
+import type { PortfolioDetailResponse } from '@entities/portfolio-form/api/types';
 import { toPortfolioFormValues } from '@entities/portfolio-form/model/adapters';
+import type { PortfolioFormValues } from '@entities/portfolio-form/model/portfolio-form';
+import { useUpdatePortfolio } from '@entities/portfolio-form/model/use-update-portfolio';
 import { ROUTE_BUILDER, ROUTE_PATH } from '@shared/constants/path';
 import { parseFieldRoleResponse } from '@shared/lib/filter/parse-field-role-response';
+import type { Option } from '@shared/types/common';
+import Loading from '@shared/ui/components/loading/loading';
+import { useToast } from '@shared/ui/components/toast/toast-context';
 import PageBackHeader from '@widgets/page-back-header/page-back-header';
 import PortfolioFormContent from '@widgets/portfolio-form/portfolio-form-content';
 import { useMemo, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import * as styles from './edit-portfolio.css';
-import { MOCK_PORTFOLIO_DETAIL } from './mock/mock-portfolio-detail';
+
+interface EditPortfolioFormProps {
+  portfolioId: string;
+  portfolioDetail: PortfolioDetailResponse;
+  roleFields: Option[];
+  rolesByFieldOptions: Record<number, Option[]>;
+  domainOptions: Option[];
+}
+
+const EditPortfolioForm = ({
+  portfolioId,
+  portfolioDetail,
+  roleFields,
+  rolesByFieldOptions,
+  domainOptions,
+}: EditPortfolioFormProps) => {
+  const navigate = useNavigate();
+  const toast = useToast();
+
+  const [formValues, setFormValues] = useState<PortfolioFormValues>(() =>
+    toPortfolioFormValues(portfolioDetail),
+  );
+
+  const { mutateAsync: updatePortfolio, isPending } =
+    useUpdatePortfolio(portfolioId);
+
+  const handleSubmit = async () => {
+    try {
+      await updatePortfolio(formValues);
+      toast.success('포트폴리오가 수정되었어요.');
+      navigate(ROUTE_BUILDER.portfolioDetails(portfolioId));
+    } catch {
+      toast.error('포트폴리오 수정에 실패했어요. 다시 시도해 주세요.');
+    }
+  };
+
+  return (
+    <PortfolioFormContent
+      values={formValues}
+      onChange={setFormValues}
+      roleFields={roleFields}
+      rolesByFieldOptions={rolesByFieldOptions}
+      domainOptions={domainOptions}
+      onSubmit={handleSubmit}
+      submitLabel={isPending ? '수정 중...' : '수정하기'}
+      disabled={isPending}
+    />
+  );
+};
 
 const EditPortfolioPage = () => {
   const { portfolioId } = useParams();
 
   const { data: fieldRoleData } = useGetFieldRole();
   const { data: domainData } = useGetDomains();
+  const {
+    data: portfolioDetail,
+    isLoading,
+    isError,
+  } = useGetMyPortfolioDetail(portfolioId);
 
   const { fields: roleFields, rolesByFieldOptions } = useMemo(
     () => parseFieldRoleResponse(fieldRoleData ?? []),
@@ -24,17 +84,15 @@ const EditPortfolioPage = () => {
 
   const domainOptions = domainData ?? [];
 
-  // TODO: GET /api/portfolios/:portfolioId 연결
-  const portfolioDetail = MOCK_PORTFOLIO_DETAIL;
+  if (isLoading) return <Loading />;
 
-  const [formValues, setFormValues] = useState(
-    toPortfolioFormValues(portfolioDetail),
-  );
-
-  const handleSubmit = () => {
-    // TODO: PATCH /api/portfolios/:portfolioId 연결
-    console.log(formValues);
-  };
+  if (isError || portfolioDetail == null || portfolioId == null) {
+    return (
+      <main className={styles.pageContainer}>
+        <p>포트폴리오를 불러올 수 없어요.</p>
+      </main>
+    );
+  }
 
   return (
     <>
@@ -51,14 +109,12 @@ const EditPortfolioPage = () => {
       </section>
 
       <main className={styles.pageContainer}>
-        <PortfolioFormContent
-          values={formValues}
-          onChange={setFormValues}
+        <EditPortfolioForm
+          portfolioId={portfolioId}
+          portfolioDetail={portfolioDetail}
           roleFields={roleFields}
           rolesByFieldOptions={rolesByFieldOptions}
           domainOptions={domainOptions}
-          onSubmit={handleSubmit}
-          submitLabel='수정하기'
         />
       </main>
     </>

--- a/src/pages/edit-portfolio/edit-portfolio.tsx
+++ b/src/pages/edit-portfolio/edit-portfolio.tsx
@@ -35,9 +35,21 @@ const EditPortfolioForm = ({
   const navigate = useNavigate();
   const toast = useToast();
 
-  const [formValues, setFormValues] = useState<PortfolioFormValues>(() =>
-    toPortfolioFormValues(portfolioDetail),
-  );
+  const [formValues, setFormValues] = useState<PortfolioFormValues>(() => {
+    const base = toPortfolioFormValues(portfolioDetail);
+
+    const fieldId =
+      base.roleId != null
+        ? (Object.entries(rolesByFieldOptions).find(([, roles]) =>
+            roles.some((r) => r.id === base.roleId),
+          )?.[0] ?? null)
+        : null;
+
+    return {
+      ...base,
+      fieldId: fieldId != null ? Number(fieldId) : null,
+    };
+  });
 
   const { mutateAsync: updatePortfolio, isPending } =
     useUpdatePortfolio(portfolioId);


### PR DESCRIPTION
## 📌 Summary

>#139
내 포트폴리오 수정하기 API 연동

## 📚 Tasks

- 포트폴리오 수정하기 API 함수, 훅 작성
- PATCH API 연동

## 🔍 Describe 

- 포트폴리오 수정하기 API 함수, 훅 작성
- PATCH API 연동

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 포트폴리오 편집 및 업데이트 기능 구현
  * 포트폴리오 상세 정보를 실시간으로 로드하여 표시하고 로딩/오류 상태 처리 추가
  * 제목, 요약, 도메인, 역할, 이미지 등 포트폴리오 정보 수정 지원 및 이미지 업로드 처리
  * 수정 완료 시 확인 알림 제공 및 상세 페이지로 자동 이동
  * 편집 폼 로직을 별도 컴포넌트/훅으로 분리하여 제출 흐름과 상태 관리를 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2025-TEAM-LGTM/UniON-client/pull/144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->