### PR TITLE
[Feat] 공고 삭제 API 연동

### DIFF
--- a/src/entities/posts/api/posts-api.ts
+++ b/src/entities/posts/api/posts-api.ts
@@ -1,5 +1,5 @@
 import type { CreatePostRequest } from '@entities/post-create/api/types';
-import { get, patch } from '@shared/api/http';
+import { del, get, patch } from '@shared/api/http';
 
 import type { PostsDataResponse } from './types';
 
@@ -27,4 +27,8 @@ export const updatePost = (
     `/api/posts/${postId}`,
     body,
   );
+};
+
+export const deletePost = (postId: number): Promise<number> => {
+  return del<number>(`/api/posts/${postId}`);
 };

--- a/src/entities/posts/api/use-delete-post.ts
+++ b/src/entities/posts/api/use-delete-post.ts
@@ -1,0 +1,17 @@
+import { queryKeys } from '@shared/constants/query-keys';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deletePost } from './posts-api';
+
+export const useDeletePost = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (postId: number) => deletePost(postId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.posts.all,
+      });
+    },
+  });
+};

--- a/src/pages/post-details/post-details.tsx
+++ b/src/pages/post-details/post-details.tsx
@@ -75,7 +75,6 @@ const PostDetailPage = () => {
 
   const handleEdit = () => {
     if (!postId) return;
-    toast.success('공고 수정이 완료되었어요.');
     navigate(ROUTE_BUILDER.postEdit(postId));
   };
 

--- a/src/pages/post-details/post-details.tsx
+++ b/src/pages/post-details/post-details.tsx
@@ -1,6 +1,7 @@
 import { useGetPostDetail } from '@entities/post-details/api/use-get-post-detail';
+import { useDeletePost } from '@entities/posts/api/use-delete-post';
 import { useToggleApply } from '@entities/posts/api/use-toggle-apply';
-import { ROUTE_BUILDER } from '@shared/constants/path';
+import { ROUTE_BUILDER, ROUTE_PATH } from '@shared/constants/path';
 import CtaButton from '@shared/ui/components/cta-button/cta-button';
 import Loading from '@shared/ui/components/loading/loading';
 import { useToast } from '@shared/ui/components/toast/toast-context';
@@ -23,6 +24,7 @@ const PostDetailPage = () => {
 
   const { data, isLoading, isError } = useGetPostDetail(numericPostId);
   const { mutateAsync: toggleApply } = useToggleApply();
+  const { mutateAsync: deletePost, isPending: isDeleting } = useDeletePost();
 
   const isAuthor = data?.owner ?? false;
 
@@ -59,13 +61,21 @@ const PostDetailPage = () => {
     }
   };
 
-  const handleDelete = () => {
-    // TODO: 삭제하기 API 연결
-    toast.success('삭제가 완료되었어요.');
+  const handleDelete = async () => {
+    if (!postId) return;
+
+    try {
+      await deletePost(numericPostId);
+      toast.success('공고가 삭제되었어요.');
+      navigate(ROUTE_PATH.POSTS);
+    } catch {
+      toast.error('공고 삭제에 실패했어요. 다시 시도해 주세요.');
+    }
   };
 
   const handleEdit = () => {
     if (!postId) return;
+    toast.success('공고 수정이 완료되었어요.');
     navigate(ROUTE_BUILDER.postEdit(postId));
   };
 
@@ -103,10 +113,18 @@ const PostDetailPage = () => {
           <div className={styles.ctaContainer}>
             {isAuthor ? (
               <>
-                <CtaButton color='gray' onClick={handleDelete}>
-                  삭제하기
+                <CtaButton
+                  color='gray'
+                  onClick={handleDelete}
+                  disabled={isDeleting}
+                >
+                  {isDeleting ? '삭제 중...' : '삭제하기'}
                 </CtaButton>
-                <CtaButton color='primary' onClick={handleEdit}>
+                <CtaButton
+                  color='primary'
+                  onClick={handleEdit}
+                  disabled={isDeleting}
+                >
                   수정하기
                 </CtaButton>
               </>

--- a/src/pages/post-details/post-details.tsx
+++ b/src/pages/post-details/post-details.tsx
@@ -63,11 +63,15 @@ const PostDetailPage = () => {
 
   const handleDelete = async () => {
     if (!postId) return;
+    if (!Number.isInteger(numericPostId) || numericPostId <= 0) {
+      toast.error('유효하지 않은 공고입니다.');
+      return;
+    }
 
     try {
       await deletePost(numericPostId);
       toast.success('공고가 삭제되었어요.');
-      navigate(ROUTE_PATH.POSTS);
+      navigate(ROUTE_PATH.POSTS, { replace: true });
     } catch {
       toast.error('공고 삭제에 실패했어요. 다시 시도해 주세요.');
     }


### PR DESCRIPTION
## 📌 Summary

> #142 
공고 삭제 API 연동

## 📚 Tasks

- 삭제 API 함수, 훅 작성
- postDetailsPage에 삭제 API 연결
  
## 🔍 Describe


- 삭제 API 함수, 훅 작성
- postDetailsPage에 삭제 API 연결

<!--
## 👀 To Reviewer

_리뷰어에게 요청하고 싶은 내용을 작성해주세요._
-->

<!--
## 📸 Screenshot

(기재 내용 없을 경우 섹션 삭제) 작업한 내용에 대한 스크린샷을 첨부해주세요.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 게시글 삭제 기능을 추가했습니다. 게시글 작성자는 상세 페이지에서 삭제 버튼을 통해 게시글을 삭제할 수 있습니다.
  * 삭제 진행 중 버튼이 비활성화되고 상태 표시가 변경되어 사용자 경험이 개선되었습니다.
  * 삭제 완료 후 자동으로 게시글 목록으로 이동합니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/2025-TEAM-LGTM/UniON-client/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->